### PR TITLE
PyPy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=pypy
 install: 
   - pip install -r requirements-dev.txt
   - pip install -U tox codecov

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -17,6 +17,8 @@ from jose.exceptions import JWKError
 from jose.exceptions import JWSError
 from jose.exceptions import JOSEError
 
+# PyCryptodome's RSA module doesn't have PyCrypto's _RSAobj class
+# Instead it has a class named RsaKey, which serves the same purpose.
 if hasattr(RSA, '_RSAobj'):
     _RSAKey = RSA._RSAobj
 else:

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -2,7 +2,6 @@
 import hashlib
 import hmac
 import six
-import struct
 
 import Crypto.Hash.SHA256
 import Crypto.Hash.SHA384
@@ -17,6 +16,11 @@ from jose.constants import ALGORITHMS
 from jose.exceptions import JWKError
 from jose.exceptions import JWSError
 from jose.exceptions import JOSEError
+
+if hasattr(RSA, '_RSAobj'):
+    _RSAKey = RSA._RSAobj
+else:
+    _RSAKey = RSA.RsaKey
 
 
 def get_algorithm_object(algorithm):
@@ -204,7 +208,7 @@ class RSAKey(Key):
 
     def process_prepare_key(self, key):
 
-        if isinstance(key, (RSA._RSAobj, RSAKey)):
+        if isinstance(key, (_RSAKey, RSAKey)):
             return key
 
         if isinstance(key, dict):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import os
 
 import jose
 
+import platform
+
 from setuptools import setup
 
 
@@ -19,6 +21,18 @@ def get_packages(package):
         dirpath
         for dirpath, dirnames, filenames in os.walk(package)
         if os.path.exists(os.path.join(dirpath, '__init__.py'))
+    ]
+
+
+def get_install_requires():
+    if platform.python_implementation() == 'PyPy':
+        crypto_lib = 'pycryptodome >=3.3.1, <3.4.0'
+    else:
+        crypto_lib = 'pycrypto >=2.6.0, <2.7.0'
+    return [
+        crypto_lib,
+        'six >=1.9.0, <1.10.0',
+        'ecdsa <1.0',
     ]
 
 
@@ -43,11 +57,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
     ],
-    install_requires=[
-        'pycrypto >=2.6.0, <2.7.0',
-        'six >=1.9.0, <1.10.0',
-        'ecdsa <1.0',
-    ]
+    install_requires=get_install_requires()
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34}
+envlist = py{26,27,33,34,py}
 
 [testenv]
 commands =


### PR DESCRIPTION
[PyCrypto](https://github.com/dlitz/pycrypto) doesn't support PyPy. This patch uses [PyCryptodome](https://github.com/Legrandin/pycryptodome) which is almost completely backwards compatible with PyCrypto if setup.py is run on PyPy. Also the compatibility with PyCrypto is not broken in any way.