### PR TITLE
Make `get_unverified_claims()` return a dict

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -124,7 +124,11 @@ def get_unverified_claims(token):
         JWSError: If there is an exception decoding the token.
     """
     header, claims, signing_input, signature = _load(token)
-    return claims
+
+    try:
+        return json.loads(claims.decode('utf-8'))
+    except ValueError as e:
+        raise JWSError('Invalid claims string: %s' % e)
 
 
 def _encode_header(algorithm, additional_headers=None):

--- a/jose/jws.py
+++ b/jose/jws.py
@@ -124,11 +124,7 @@ def get_unverified_claims(token):
         JWSError: If there is an exception decoding the token.
     """
     header, claims, signing_input, signature = _load(token)
-
-    try:
-        return json.loads(claims.decode('utf-8'))
-    except ValueError as e:
-        raise JWSError('Invalid claims string: %s' % e)
+    return claims
 
 
 def _encode_header(algorithm, additional_headers=None):

--- a/jose/jws.py
+++ b/jose/jws.py
@@ -118,7 +118,7 @@ def get_unverified_claims(token):
         token (str): A signed JWS to decode the headers from.
 
     Returns:
-        dict: The dict representation of the token claims.
+        str: The str representation of the token claims.
 
     Raises:
         JWSError: If there is an exception decoding the token.

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -185,9 +185,14 @@ def get_unverified_claims(token):
         raise JWTError('Error decoding token claims.')
 
     try:
-        return json.loads(claims.decode('utf-8'))
+        claims = json.loads(claims.decode('utf-8'))
     except ValueError as e:
         raise JWTError('Invalid claims string: %s' % e)
+
+    if not isinstance(claims, Mapping):
+        raise JWTError('Invalid claims string: must be a json object')
+
+    return claims
 
 
 def _validate_iat(claims):

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -184,7 +184,10 @@ def get_unverified_claims(token):
     except:
         raise JWTError('Error decoding token claims.')
 
-    return claims
+    try:
+        return json.loads(claims.decode('utf-8'))
+    except ValueError as e:
+        raise JWTError('Invalid claims string: %s' % e)
 
 
 def _validate_iat(claims):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -402,3 +402,17 @@ class TestJWT:
         token = jwt.encode(claims, key)
         with pytest.raises(JWTError):
             jwt.decode(token, key)
+
+    def test_unverified_claims_string(self):
+        token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.aW52YWxpZCBjbGFpbQ.iOJ5SiNfaNO_pa2J4Umtb3b3zmk5C18-mhTCVNsjnck'
+        with pytest.raises(JWTError):
+            jwt.get_unverified_claims(token)
+
+    def test_unverified_claims_list(self):
+        token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.WyJpbnZhbGlkIiwgImNsYWltcyJd.nZvw_Rt1FfUPb5OiVbrSYZGtWSE5c-gdJ6nQnTTBkYo'
+        with pytest.raises(JWTError):
+            jwt.get_unverified_claims(token)
+
+    def test_unverified_claims_object(self, claims, key):
+        token = jwt.encode(claims, key)
+        assert jwt.get_unverified_claims(token) == claims


### PR DESCRIPTION
So far the above method returned the unprocessed string it received from
`_load()`.

This commit parses the payload before returning it in order to comply
with the documentation.