### PR TITLE
Validate specific subject of JWT

### DIFF
--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -380,6 +380,29 @@ class TestJWT:
         with pytest.raises(JWTError):
             jwt.decode(token, key)
 
+    def test_sub_correct(self, key):
+
+        sub = 'subject'
+
+        claims = {
+            'sub': sub
+        }
+
+        token = jwt.encode(claims, key)
+        jwt.decode(token, key, subject=sub)
+
+    def test_sub_incorrect(self, key):
+
+        sub = 'subject'
+
+        claims = {
+            'sub': sub
+        }
+
+        token = jwt.encode(claims, key)
+        with pytest.raises(JWTError):
+            jwt.decode(token, key, subject='another')
+
     def test_jti_string(self, key):
 
         jti = 'JWT ID'


### PR DESCRIPTION
Allow the user to validate that the subject of a JWT is the specific
value that they expect.