### PR TITLE
Easier extending/replacing of key algorithms

### DIFF
--- a/jose/constants.py
+++ b/jose/constants.py
@@ -35,25 +35,13 @@ class Algorithms(object):
 
     KEYS = {}
 
-    def get_key(self, algorithm):
-        from jose.jwk import HMACKey, RSAKey, ECKey
-        if algorithm in self.KEYS:
-            return self.KEYS[algorithm]
-        elif algorithm in self.HMAC:
-            return HMACKey
-        elif algorithm in self.RSA:
-            return RSAKey
-        elif algorithm in self.EC:
-            return ECKey
-        return None
-
     def register_key(self, algorithm, key_class):
         from jose.jwk import Key
-        if issubclass(key_class, Key):
-            self.KEYS[algorithm] = key_class
-            self.SUPPORTED.add(algorithm)
-            return True
-        else:
-            return False
+        if not issubclass(key_class, Key):
+            raise TypeError("Key class not a subclass of jwk.Key")
+        self.KEYS[algorithm] = key_class
+        self.SUPPORTED.add(algorithm)
+        return True
+
 
 ALGORITHMS = Algorithms()

--- a/jose/constants.py
+++ b/jose/constants.py
@@ -1,6 +1,7 @@
 import hashlib
 
-class ALGORITHMS(object):
+
+class Algorithms(object):
     NONE = 'none'
     HS256 = 'HS256'
     HS384 = 'HS384'
@@ -12,13 +13,13 @@ class ALGORITHMS(object):
     ES384 = 'ES384'
     ES512 = 'ES512'
 
-    HMAC = (HS256, HS384, HS512)
-    RSA = (RS256, RS384, RS512)
-    EC = (ES256, ES384, ES512)
+    HMAC = set([HS256, HS384, HS512])
+    RSA = set([RS256, RS384, RS512])
+    EC = set([ES256, ES384, ES512])
 
-    SUPPORTED = HMAC + RSA + EC
+    SUPPORTED = HMAC.union(RSA).union(EC)
 
-    ALL = SUPPORTED + (NONE, )
+    ALL = SUPPORTED.union([NONE])
 
     HASHES = {
         HS256: hashlib.sha256,
@@ -31,3 +32,22 @@ class ALGORITHMS(object):
         ES384: hashlib.sha384,
         ES512: hashlib.sha512,
     }
+
+    KEYS = {}
+
+    def get_key(self, algorithm):
+        from jose.jwk import HMACKey, RSAKey, ECKey
+        if algorithm in self.KEYS:
+            return self.KEYS[algorithm]
+        elif algorithm in self.HMAC:
+            return HMACKey
+        elif algorithm in self.RSA:
+            return RSAKey
+        elif algorithm in self.EC:
+            return ECKey
+
+    def register_key(self, algorithm, key_class):
+        self.KEYS[algorithm] = key_class
+        self.SUPPORTED.add(algorithm)
+
+ALGORITHMS = Algorithms()

--- a/jose/constants.py
+++ b/jose/constants.py
@@ -45,9 +45,15 @@ class Algorithms(object):
             return RSAKey
         elif algorithm in self.EC:
             return ECKey
+        return None
 
     def register_key(self, algorithm, key_class):
-        self.KEYS[algorithm] = key_class
-        self.SUPPORTED.add(algorithm)
+        from jose.jwk import Key
+        if issubclass(key_class, Key):
+            self.KEYS[algorithm] = key_class
+            self.SUPPORTED.add(algorithm)
+            return True
+        else:
+            return False
 
 ALGORITHMS = Algorithms()

--- a/jose/constants.py
+++ b/jose/constants.py
@@ -35,13 +35,5 @@ class Algorithms(object):
 
     KEYS = {}
 
-    def register_key(self, algorithm, key_class):
-        from jose.jwk import Key
-        if not issubclass(key_class, Key):
-            raise TypeError("Key class not a subclass of jwk.Key")
-        self.KEYS[algorithm] = key_class
-        self.SUPPORTED.add(algorithm)
-        return True
-
 
 ALGORITHMS = Algorithms()

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -60,14 +60,10 @@ def construct(key_data, algorithm=None):
     if not algorithm:
         raise JWKError('Unable to find a algorithm for key: %s' % key_data)
 
-    if algorithm in ALGORITHMS.HMAC:
-        return HMACKey(key_data, algorithm)
-
-    if algorithm in ALGORITHMS.RSA:
-        return RSAKey(key_data, algorithm)
-
-    if algorithm in ALGORITHMS.EC:
-        return ECKey(key_data, algorithm)
+    key_class = ALGORITHMS.get_key(algorithm)
+    if not key_class:
+        raise JWKError('Unable to find a algorithm for key: %s' % key_data)
+    return key_class(key_data, algorithm)
 
 
 def get_algorithm_object(algorithm):
@@ -112,13 +108,12 @@ class HMACKey(Key):
     SHA256 = hashlib.sha256
     SHA384 = hashlib.sha384
     SHA512 = hashlib.sha512
-    valid_hash_algs = ALGORITHMS.HMAC
 
     prepared_key = None
     hash_alg = None
 
     def __init__(self, key, algorithm):
-        if algorithm not in self.valid_hash_algs:
+        if algorithm not in ALGORITHMS.HMAC:
             raise JWKError('hash_alg: %s is not a valid hash algorithm' % algorithm)
         self.hash_alg = get_algorithm_object(algorithm)
 
@@ -174,14 +169,13 @@ class RSAKey(Key):
     SHA256 = Crypto.Hash.SHA256
     SHA384 = Crypto.Hash.SHA384
     SHA512 = Crypto.Hash.SHA512
-    valid_hash_algs = ALGORITHMS.RSA
 
     prepared_key = None
     hash_alg = None
 
     def __init__(self, key, algorithm):
 
-        if algorithm not in self.valid_hash_algs:
+        if algorithm not in ALGORITHMS.RSA:
             raise JWKError('hash_alg: %s is not a valid hash algorithm' % algorithm)
         self.hash_alg = get_algorithm_object(algorithm)
 
@@ -257,7 +251,6 @@ class ECKey(Key):
     SHA256 = hashlib.sha256
     SHA384 = hashlib.sha384
     SHA512 = hashlib.sha512
-    valid_hash_algs = ALGORITHMS.EC
 
     curve_map = {
         SHA256: ecdsa.curves.NIST256p,
@@ -270,7 +263,7 @@ class ECKey(Key):
     curve = None
 
     def __init__(self, key, algorithm):
-        if algorithm not in self.valid_hash_algs:
+        if algorithm not in ALGORITHMS.EC:
             raise JWKError('hash_alg: %s is not a valid hash algorithm' % algorithm)
         self.hash_alg = get_algorithm_object(algorithm)
 

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -47,6 +47,18 @@ def base64_to_long(data):
     return int_arr_to_long(struct.unpack('%sB' % len(_d), _d))
 
 
+def get_key(algorithm):
+    if algorithm in ALGORITHMS.KEYS:
+        return ALGORITHMS.KEYS[algorithm]
+    elif algorithm in ALGORITHMS.HMAC:
+        return HMACKey
+    elif algorithm in ALGORITHMS.RSA:
+        return RSAKey
+    elif algorithm in ALGORITHMS.EC:
+        return ECKey
+    return None
+
+
 def construct(key_data, algorithm=None):
     """
     Construct a Key object for the given algorithm with the given
@@ -60,7 +72,7 @@ def construct(key_data, algorithm=None):
     if not algorithm:
         raise JWKError('Unable to find a algorithm for key: %s' % key_data)
 
-    key_class = ALGORITHMS.get_key(algorithm)
+    key_class = get_key(algorithm)
     if not key_class:
         raise JWKError('Unable to find a algorithm for key: %s' % key_data)
     return key_class(key_data, algorithm)

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -59,6 +59,14 @@ def get_key(algorithm):
     return None
 
 
+def register_key(algorithm, key_class):
+    if not issubclass(key_class, Key):
+        raise TypeError("Key class not a subclass of jwk.Key")
+    ALGORITHMS.KEYS[algorithm] = key_class
+    ALGORITHMS.SUPPORTED.add(algorithm)
+    return True
+
+
 def construct(key_data, algorithm=None):
     """
     Construct a Key object for the given algorithm with the given

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -87,11 +87,8 @@ class Key(object):
     """
     A simple interface for implementing JWK keys.
     """
-    prepared_key = None
-    hash_alg = None
-
-    def _process_jwk(self, jwk_dict):
-        raise NotImplementedError()
+    def __init__(self, key, algorithm):
+        pass
 
     def sign(self, msg):
         raise NotImplementedError()
@@ -108,9 +105,6 @@ class HMACKey(Key):
     SHA256 = hashlib.sha256
     SHA384 = hashlib.sha384
     SHA512 = hashlib.sha512
-
-    prepared_key = None
-    hash_alg = None
 
     def __init__(self, key, algorithm):
         if algorithm not in ALGORITHMS.HMAC:
@@ -169,9 +163,6 @@ class RSAKey(Key):
     SHA256 = Crypto.Hash.SHA256
     SHA384 = Crypto.Hash.SHA384
     SHA512 = Crypto.Hash.SHA512
-
-    prepared_key = None
-    hash_alg = None
 
     def __init__(self, key, algorithm):
 
@@ -236,7 +227,7 @@ class RSAKey(Key):
         try:
             return PKCS1_v1_5.new(self.prepared_key).verify(self.hash_alg.new(msg), sig)
         except Exception as e:
-            raise JWKError(e)
+            return False
 
 
 class ECKey(Key):
@@ -252,22 +243,18 @@ class ECKey(Key):
     SHA384 = hashlib.sha384
     SHA512 = hashlib.sha512
 
-    curve_map = {
+    CURVE_MAP = {
         SHA256: ecdsa.curves.NIST256p,
         SHA384: ecdsa.curves.NIST384p,
         SHA512: ecdsa.curves.NIST521p,
     }
-
-    prepared_key = None
-    hash_alg = None
-    curve = None
 
     def __init__(self, key, algorithm):
         if algorithm not in ALGORITHMS.EC:
             raise JWKError('hash_alg: %s is not a valid hash algorithm' % algorithm)
         self.hash_alg = get_algorithm_object(algorithm)
 
-        self.curve = self.curve_map.get(self.hash_alg)
+        self.curve = self.CURVE_MAP.get(self.hash_alg)
 
         if isinstance(key, (ecdsa.SigningKey, ecdsa.VerifyingKey)):
             self.prepared_key = key

--- a/tests/algorithms/test_base.py
+++ b/tests/algorithms/test_base.py
@@ -23,15 +23,10 @@ class TestBaseAlgorithm:
 
 class TestAlgorithms:
 
-    def test_get_key(self):
-        assert ALGORITHMS.get_key("HS256") == HMACKey
-        assert ALGORITHMS.get_key("RS256") == RSAKey
-        assert ALGORITHMS.get_key("ES256") == ECKey
-
-        assert ALGORITHMS.get_key("NONEXISTENT") == None
-    
     def test_register_key(self):
-        assert ALGORITHMS.register_key("ALG", Key) == True
-        assert ALGORITHMS.get_key("ALG") == Key
-
-        assert ALGORITHMS.register_key("ALG", object) == False
+        assert ALGORITHMS.register_key("ALG", Key)
+        from jose.jwk import get_key
+        assert get_key("ALG") == Key
+    
+        with pytest.raises(TypeError):
+            assert ALGORITHMS.register_key("ALG", object)

--- a/tests/algorithms/test_base.py
+++ b/tests/algorithms/test_base.py
@@ -1,25 +1,37 @@
 
-# from jose.jwk import Key
-# from jose.exceptions import JOSEError
+from jose.jwk import Key, HMACKey, RSAKey, ECKey
+from jose.constants import ALGORITHMS
 
-# import pytest
-
-
-# @pytest.fixture
-# def alg():
-#     return Key()
+import pytest
 
 
-# class TestBaseAlgorithm:
+@pytest.fixture
+def alg():
+    return Key("key", "ALG")
 
-#     def test_prepare_key_is_interface(self, alg):
-#         with pytest.raises(JOSEError):
-#             alg.prepare_key('secret')
 
-#     def test_sign_is_interface(self, alg):
-#         with pytest.raises(JOSEError):
-#             alg.sign('msg', 'secret')
+class TestBaseAlgorithm:
 
-#     def test_verify_is_interface(self, alg):
-#         with pytest.raises(JOSEError):
-#             alg.verify('msg', 'secret', 'sig')
+    def test_sign_is_interface(self, alg):
+        with pytest.raises(NotImplementedError):
+            alg.sign('msg')
+
+    def test_verify_is_interface(self, alg):
+        with pytest.raises(NotImplementedError):
+            alg.verify('msg', 'sig')
+
+
+class TestAlgorithms:
+
+    def test_get_key(self):
+        assert ALGORITHMS.get_key("HS256") == HMACKey
+        assert ALGORITHMS.get_key("RS256") == RSAKey
+        assert ALGORITHMS.get_key("ES256") == ECKey
+
+        assert ALGORITHMS.get_key("NONEXISTENT") == None
+    
+    def test_register_key(self):
+        assert ALGORITHMS.register_key("ALG", Key) == True
+        assert ALGORITHMS.get_key("ALG") == Key
+
+        assert ALGORITHMS.register_key("ALG", object) == False

--- a/tests/algorithms/test_base.py
+++ b/tests/algorithms/test_base.py
@@ -1,6 +1,4 @@
-
-from jose.jwk import Key, HMACKey, RSAKey, ECKey
-from jose.constants import ALGORITHMS
+from jose.jwk import Key
 
 import pytest
 
@@ -20,13 +18,3 @@ class TestBaseAlgorithm:
         with pytest.raises(NotImplementedError):
             alg.verify('msg', 'sig')
 
-
-class TestAlgorithms:
-
-    def test_register_key(self):
-        assert ALGORITHMS.register_key("ALG", Key)
-        from jose.jwk import get_key
-        assert get_key("ALG") == Key
-    
-        with pytest.raises(TypeError):
-            assert ALGORITHMS.register_key("ALG", object)

--- a/tests/test_jwk.py
+++ b/tests/test_jwk.py
@@ -1,9 +1,7 @@
-
 from jose import jwk
 from jose.exceptions import JWKError
 
 import pytest
-
 
 hmac_key = {
     "kty": "oct",
@@ -122,3 +120,10 @@ class TestJWK:
         assert jwk.get_key("ES256") == jwk.ECKey
 
         assert jwk.get_key("NONEXISTENT") == None
+
+    def test_register_key(self):
+        assert jwk.register_key("ALG", jwk.Key)
+        assert jwk.get_key("ALG") == jwk.Key
+
+        with pytest.raises(TypeError):
+            assert jwk.register_key("ALG", object)

--- a/tests/test_jwk.py
+++ b/tests/test_jwk.py
@@ -115,3 +115,10 @@ class TestJWK:
 
         with pytest.raises(JWKError):
             key = jwk.construct("key", algorithm="NONEXISTENT")
+
+    def test_get_key(self):
+        assert jwk.get_key("HS256") == jwk.HMACKey
+        assert jwk.get_key("RS256") == jwk.RSAKey
+        assert jwk.get_key("ES256") == jwk.ECKey
+
+        assert jwk.get_key("NONEXISTENT") == None

--- a/tests/test_jwk.py
+++ b/tests/test_jwk.py
@@ -35,10 +35,7 @@ class TestJWK:
 
     def test_interface(self):
 
-        key = jwk.Key()
-
-        with pytest.raises(NotImplementedError):
-            key._process_jwk(None)
+        key = jwk.Key("key", "ALG")
 
         with pytest.raises(NotImplementedError):
             key.sign('')
@@ -115,3 +112,6 @@ class TestJWK:
 
         with pytest.raises(JWKError):
             key = jwk.construct(hmac_key)
+
+        with pytest.raises(JWKError):
+            key = jwk.construct("key", algorithm="NONEXISTENT")


### PR DESCRIPTION
Changed some code to make jwk algorithm implementations easily extendable.

If you want to replace a certain key implementation you only do `jwk.ALGORITHMS.register_key("[algorithm name]", [key class])` and from that moment on the algorithm will use a different class to do everything.

While doing it, made some stuff a bit more pythonic.