### PR TITLE
Fix for just released cryptography 1.9.

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -97,7 +97,8 @@ class CryptographyECKey(Key):
         verifier = self.prepared_key.verifier(signature, ec.ECDSA(self.hash_alg()))
         verifier.update(msg)
         try:
-            return verifier.verify()
+            verifier.verify()
+            return True
         except:
             return False
 


### PR DESCRIPTION
Cryptography 1.9 has a backwards incompatible API change in ECC where a signature verification function does not return True anymore.