### PR TITLE
Implement pure python rsa signing based on rsa module

### DIFF
--- a/jose/backends/__init__.py
+++ b/jose/backends/__init__.py
@@ -2,7 +2,10 @@
 try:
     from jose.backends.pycrypto_backend import RSAKey
 except ImportError:
-    from jose.backends.cryptography_backend import CryptographyRSAKey as RSAKey
+    try:
+        from jose.backends.cryptography_backend import CryptographyRSAKey as RSAKey
+    except ImportError:
+        from jose.backends.rsa_backend import RSAKey
 
 try:
     from jose.backends.cryptography_backend import CryptographyECKey as ECKey

--- a/jose/backends/rsa_backend.py
+++ b/jose/backends/rsa_backend.py
@@ -1,0 +1,83 @@
+import rsa as pyrsa
+import six
+
+from jose.backends.base import Key
+from jose.constants import ALGORITHMS
+from jose.exceptions import JWKError
+from jose.utils import base64_to_long
+
+
+class RSAKey(Key):
+    SHA256 = 'SHA-256'
+    SHA384 = 'SHA-384'
+    SHA512 = 'SHA-512'
+
+    def __init__(self, key, algorithm):
+        if algorithm not in ALGORITHMS.RSA:
+            raise JWKError('hash_alg: %s is not a valid hash algorithm' % algorithm)
+
+        self.hash_alg = {
+            ALGORITHMS.RS256: self.SHA256,
+            ALGORITHMS.RS384: self.SHA384,
+            ALGORITHMS.RS512: self.SHA512
+        }.get(algorithm)
+        self._algorithm = algorithm
+
+        if isinstance(key, dict):
+            self.prepared_key = self._process_jwk(key)
+            return
+
+        if isinstance(key, (pyrsa.PublicKey, pyrsa.PrivateKey)):
+            self._prepared_key = key
+            return
+
+        if isinstance(key, six.string_types):
+            key = key.encode('utf-8')
+
+        if isinstance(key, six.binary_type):
+            try:
+                self._prepared_key = pyrsa.PublicKey.load_pkcs1(key)
+            except ValueError:
+                try:
+                    self._prepared_key = pyrsa.PrivateKey.load_pkcs1(key)
+                except ValueError as e:
+                    raise JWKError(e)
+            return
+        raise JWKError('Unable to parse an RSA_JWK from key: %s' % key)
+
+    def _process_jwk(self, jwk_dict):
+        if not jwk_dict.get('kty') == 'RSA':
+            raise JWKError("Incorrect key type.  Expected: 'RSA', Recieved: %s" % jwk_dict.get('kty'))
+
+        e = base64_to_long(jwk_dict.get('e', 256))
+        n = base64_to_long(jwk_dict.get('n'))
+
+        verifying_key = pyrsa.PublicKey(e=e, n=n)
+        return verifying_key
+
+    def sign(self, msg):
+        print(self._algorithm)
+        return pyrsa.sign(msg, self._prepared_key, self.hash_alg)
+
+    def verify(self, msg, sig):
+        try:
+            return pyrsa.verify(msg, sig, self._prepared_key)
+        except pyrsa.pkcs1.VerificationError:
+            return False
+
+    def public_key(self):
+        if isinstance(self._prepared_key, pyrsa.PublicKey):
+            return self
+        return self.__class__(pyrsa.PublicKey(n=self._prepared_key.n, e=self._prepared_key.e), self._algorithm)
+
+    def to_pem(self):
+        import rsa.pem
+
+        if isinstance(self._prepared_key, rsa.PrivateKey):
+            pem = self._prepared_key.save_pkcs1()
+        else:
+            # this is a PKCS#8 DER header to identify rsaEncryption
+            header = b'0\x82\x04\xbd\x02\x01\x000\r\x06\t*\x86H\x86\xf7\r\x01\x01\x01\x05\x00'
+            der = self._prepared_key.save_pkcs1(format='DER')
+            pem = rsa.pem.save_pem(header + der, pem_marker='PUBLIC KEY')
+        return pem

--- a/jose/backends/rsa_backend.py
+++ b/jose/backends/rsa_backend.py
@@ -56,12 +56,12 @@ class RSAKey(Key):
         return verifying_key
 
     def sign(self, msg):
-        print(self._algorithm)
         return pyrsa.sign(msg, self._prepared_key, self.hash_alg)
 
     def verify(self, msg, sig):
         try:
-            return pyrsa.verify(msg, sig, self._prepared_key)
+            pyrsa.verify(msg, sig, self._prepared_key)
+            return True
         except pyrsa.pkcs1.VerificationError:
             return False
 
@@ -73,7 +73,7 @@ class RSAKey(Key):
     def to_pem(self):
         import rsa.pem
 
-        if isinstance(self._prepared_key, rsa.PrivateKey):
+        if isinstance(self._prepared_key, pyrsa.PrivateKey):
             pem = self._prepared_key.save_pkcs1()
         else:
             # this is a PKCS#8 DER header to identify rsaEncryption

--- a/jose/backends/rsa_backend.py
+++ b/jose/backends/rsa_backend.py
@@ -49,7 +49,7 @@ class RSAKey(Key):
         if not jwk_dict.get('kty') == 'RSA':
             raise JWKError("Incorrect key type.  Expected: 'RSA', Recieved: %s" % jwk_dict.get('kty'))
 
-        e = base64_to_long(jwk_dict.get('e', 256))
+        e = base64_to_long(jwk_dict.get('e'))
         n = base64_to_long(jwk_dict.get('n'))
 
         verifying_key = pyrsa.PublicKey(e=e, n=n)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pycrypto
 six
 future
+rsa
+ecdsa

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ def get_install_requires():
         'six <2.0',
         'ecdsa <1.0',
         'future <1.0',
+        'rsa'
     ]
 
 

--- a/tests/algorithms/test_RSA.py
+++ b/tests/algorithms/test_RSA.py
@@ -3,6 +3,7 @@ import sys
 
 from jose.backends.pycrypto_backend import RSAKey
 from jose.backends.cryptography_backend import CryptographyRSAKey
+from jose.backends.rsa_backend import RSAKey as PurePythonRSAKey
 from jose.constants import ALGORITHMS
 from jose.exceptions import JOSEError, JWKError
 
@@ -162,6 +163,98 @@ class TestRSACryptography:
         key1 = RSAKey(private_key, ALGORITHMS.RS256)
         vkey1 = key1.public_key()
         key2 = CryptographyRSAKey(private_key, ALGORITHMS.RS256)
+        vkey2 = key2.public_key()
+
+        msg = b'test'
+        sig1 = key1.sign(msg)
+        sig2 = key2.sign(msg)
+
+        assert vkey1.verify(msg, sig1)
+        assert vkey1.verify(msg, sig2)
+        assert vkey2.verify(msg, sig1)
+        assert vkey2.verify(msg, sig2)
+
+        # invalid signature
+        assert not vkey2.verify(msg, b'n' * 64)
+
+    def test_pycrypto_invalid_signature(self):
+
+        key = RSAKey(private_key, ALGORITHMS.RS256)
+        msg = b'test'
+        signature = key.sign(msg)
+        public_key = key.public_key()
+
+        assert public_key.verify(msg, signature) == True
+        assert public_key.verify(msg, 1) == False
+
+
+class TestPythonRSA:
+    def test_RSA_key(self):
+        PurePythonRSAKey(private_key, ALGORITHMS.RS256)
+
+    def test_RSA_key_instance(self):
+        import rsa
+        key = rsa.PublicKey(
+            e=65537,
+            n=26057131595212989515105618545799160306093557851986992545257129318694524535510983041068168825614868056510242030438003863929818932202262132630250203397069801217463517914103389095129323580576852108653940669240896817348477800490303630912852266209307160550655497615975529276169196271699168537716821419779900117025818140018436554173242441334827711966499484119233207097432165756707507563413323850255548329534279691658369466534587631102538061857114141268972476680597988266772849780811214198186940677291891818952682545840788356616771009013059992237747149380197028452160324144544057074406611859615973035412993832273216732343819,
+        )
+
+        pubkey = PurePythonRSAKey(key, ALGORITHMS.RS256)
+        pem = pubkey.to_pem()
+        assert pem.startswith(b'-----BEGIN PUBLIC KEY-----')
+
+    def test_invalid_algorithm(self):
+        with pytest.raises(JWKError):
+            PurePythonRSAKey(private_key, ALGORITHMS.ES256)
+
+        with pytest.raises(JWKError):
+            PurePythonRSAKey({'kty': 'bla'}, ALGORITHMS.RS256)
+
+    def test_RSA_jwk(self):
+        d = {
+            "kty": "RSA",
+            "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+            "e": "AQAB",
+        }
+        PurePythonRSAKey(d, ALGORITHMS.RS256)
+
+    def test_string_secret(self):
+        key = 'secret'
+        with pytest.raises(JOSEError):
+            PurePythonRSAKey(key, ALGORITHMS.RS256)
+
+    def test_object(self):
+        key = object()
+        with pytest.raises(JOSEError):
+            PurePythonRSAKey(key, ALGORITHMS.RS256)
+
+    def test_bad_cert(self):
+        key = '-----BEGIN CERTIFICATE-----'
+        with pytest.raises(JOSEError):
+            PurePythonRSAKey(key, ALGORITHMS.RS256)
+
+    def test_get_public_key(self):
+        key = PurePythonRSAKey(private_key, ALGORITHMS.RS256)
+        public_key = key.public_key()
+        public_key2 = public_key.public_key()
+        assert public_key == public_key2
+
+        key = RSAKey(private_key, ALGORITHMS.RS256)
+        public_key = key.public_key()
+        public_key2 = public_key.public_key()
+        assert public_key == public_key2
+
+    def test_to_pem(self):
+        key = PurePythonRSAKey(private_key, ALGORITHMS.RS256)
+        assert key.to_pem().strip() == private_key.strip()
+
+        key = RSAKey(private_key, ALGORITHMS.RS256)
+        assert key.to_pem().strip() == private_key.strip()
+
+    def test_signing_parity(self):
+        key1 = RSAKey(private_key, ALGORITHMS.RS256)
+        vkey1 = key1.public_key()
+        key2 = PurePythonRSAKey(private_key, ALGORITHMS.RS256)
         vkey2 = key2.public_key()
 
         msg = b'test'


### PR DESCRIPTION
This offers a fallback and ensures the library is usable even when a supported fast C implementation isn't available.