### PR TITLE
Fix for CVE-2017-11424

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+# Travis infra requires pinning dist:precise, at least as of 2017-09-01
+# detail: https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
+dist: precise
 language: python
 python:
   - "2.6"

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -105,6 +105,7 @@ class HMACKey(Key):
 
         invalid_strings = [
             b'-----BEGIN PUBLIC KEY-----',
+            b'-----BEGIN RSA PUBLIC KEY-----',
             b'-----BEGIN CERTIFICATE-----',
             b'ssh-rsa'
         ]

--- a/tests/algorithms/test_HMAC.py
+++ b/tests/algorithms/test_HMAC.py
@@ -17,6 +17,10 @@ class TestHMACAlgorithm:
         with pytest.raises(JOSEError):
             HMACKey(key, ALGORITHMS.HS256)
 
+        key = "-----BEGIN RSA PUBLIC KEY-----"
+        with pytest.raises(JOSEError):
+            HMACKey(key, ALGORITHMS.HS256)
+
         key = "-----BEGIN CERTIFICATE-----"
         with pytest.raises(JOSEError):
             HMACKey(key, ALGORITHMS.HS256)


### PR DESCRIPTION
Add "RSA PUBLIC KEY" to the forbidden key strings in HMAC. Prevents the use of PKCS1 keys, cited by this CVE as exposing a key-confusion attack.
Also add a test case for it, doing the obvious thing.

Closes #62