### PR TITLE
Relax cocdecov requirements on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+# codecov.yml file, spec is visible:
+# https://github.com/codecov/support/wiki/Codecov-Yaml
+coverage:
+  status:
+    # pull-requests only
+    patch:
+      default:
+        # coverage may fall by <1% and still be considered "passing"
+        threshold: 1%


### PR DESCRIPTION
Setup `.codecov.yml` to specify that pull requests may drop up to 1% coverage and still be considered passing.

This should encourage outside contributions of small patches and changes which do not materially impact project coverage. It also, in a way, codifies a fairly reasonable policy WRT coverage expectations around new work: if you drop coverage by a small amount, that's okay, but don't reduce it by a large amount.