### PR TITLE
Move away from deprecated methods

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -101,10 +101,8 @@ class CryptographyECKey(Key):
     def verify(self, msg, sig):
         order = (2 ** self.prepared_key.curve.key_size) - 1
         signature = sigencode_der(*sigdecode_string(sig, order), order=order)
-        verifier = self.prepared_key.verifier(signature, ec.ECDSA(self.hash_alg()))
-        verifier.update(msg)
         try:
-            verifier.verify()
+            self.prepared_key.verify(signature, msg, ec.ECDSA(self.hash_alg()))
             return True
         except:
             return False
@@ -251,25 +249,23 @@ class CryptographyRSAKey(Key):
 
     def sign(self, msg):
         try:
-            signer = self.prepared_key.signer(
+            signature = self.prepared_key.sign(
+                msg,
                 padding.PKCS1v15(),
                 self.hash_alg()
             )
-            signer.update(msg)
-            signature = signer.finalize()
         except Exception as e:
             raise JWKError(e)
         return signature
 
     def verify(self, msg, sig):
-        verifier = self.prepared_key.verifier(
-            sig,
-            padding.PKCS1v15(),
-            self.hash_alg()
-        )
-        verifier.update(msg)
         try:
-            verifier.verify()
+            self.prepared_key.verify(
+                sig,
+                msg,
+                padding.PKCS1v15(),
+                self.hash_alg()
+            )
             return True
         except InvalidSignature:
             return False


### PR DESCRIPTION
I noticed that running the project unit test in `pytest`, I was getting some of the following Warnings:
```
tests/algorithms/test_EC.py::TestECAlgorithm::()::test_signing_parity[CryptographyECKey-ECDSAECKey]
  ~/python-jose/jose/backends/cryptography_backend.py:104: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
    verifier = self.prepared_key.verifier(signature, ec.ECDSA(self.hash_alg()))

tests/algorithms/test_RSA.py::TestRSAAlgorithm::()::test_signing_parity[CryptographyRSAKey-CryptographyRSAKey]
  ~/python-jose/jose/backends/cryptography_backend.py:257: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
    self.hash_alg()
  ~/python-jose/jose/backends/cryptography_backend.py:269: CryptographyDeprecationWarning: signer and verifier have been deprecated. Please use sign and verify instead.
    self.hash_alg()
```

This PR moves from `verifier`->`verify` and `signer`->`sign`.

I would _love_ a decent review of this code, just to double check that I didn't borken anything.