### PR TITLE
Fix typo, rephrase access_token doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ necessary, other RSA backends are supported. Options include crytography, pycryp
 
 In order to use a custom backend, install python-jose with the appropriate extra.
 
-It is reccomended that a custom backend is used in production, as the pure-python rsa module is slow.
+It is recommended that a custom backend is used in production, as the pure-python rsa module is slow.
 
 The crytography option is a good default.
 

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -78,8 +78,7 @@ def decode(token, key, algorithms=None, options=None, audience=None,
         subject (str): The subject of the token.  If the "sub" claim is
             included in the claim set, then the subject must be included and must equal
             the provided claim.
-        access_token (str): An access token returned alongside the id_token during
-            the authorization grant flow. If the "at_hash" claim is included in the
+        access_token (str): An access token string. If the "at_hash" claim is included in the
             claim set, then the access_token must be included, and it must match
             the "at_hash" claim.
         options (dict): A dictionary of options for skipping validation steps.


### PR DESCRIPTION
Spotted a typo on the README, and gave the ReadTheDocs pages a pass to justify the commit :)

If I overstepped on editing the access_token doc, lemme know. Seemed like some OAuth2-specific phrasing may have slipped in accidentally, where the rest doesn't refer to that protocol.