### PR TITLE
trigger tests using `python setup.py test`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,11 @@ max-line-length = 119
 
 [wheel]
 universal = 1
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --cov-report term-missing --cov jose
+testpaths = tests
+python_files = test_*.py

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,15 @@ setup(
         'Topic :: Utilities',
     ],
     extras_require=extras_require,
+    setup_requires=['pytest-runner'],
+    tests_require=[
+        'six',
+        'future',
+        'ecdsa',
+        'pytest',
+        'pytest-cov',
+        'pytest-runner',
+        'cryptography',
+    ],
     install_requires=['six <2.0', 'ecdsa <1.0', 'rsa', 'future <1.0']
 )


### PR DESCRIPTION
This patch will allow you to run test using `python setup.py test` command.

See https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner