### PR TITLE
update comments for key argument

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -18,7 +18,8 @@ def sign(payload, key, headers=None, algorithm=ALGORITHMS.HS256):
 
     Args:
         payload (str): A string to sign
-        key (str): The key to use for signing the claim set
+        key (str or dict): The key to use for signing the claim set. Can be
+            individual JWK or JWK set.
         headers (dict, optional): A set of headers that will be added to
             the default headers.  Any headers that are added as additional
             headers will override the default headers.
@@ -53,7 +54,8 @@ def verify(token, key, algorithms, verify=True):
 
     Args:
         token (str): A signed JWS to be verified.
-        key (str): A key to attempt to verify the payload with.
+        key (str or dict): A key to attempt to verify the payload with. Can be
+            individual JWK or JWK set.
         algorithms (str or list): Valid algorithms that should be used to verify the JWS.
 
     Returns:

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -25,7 +25,8 @@ def encode(claims, key, algorithm=ALGORITHMS.HS256, headers=None, access_token=N
 
     Args:
         claims (dict): A claims set to sign
-        key (str): The key to use for signing the claim set
+        key (str or dict): The key to use for signing the claim set. Can be
+            individual JWK or JWK set.
         algorithm (str, optional): The algorithm to use for signing the
             the claims.  Defaults to HS256.
         headers (dict, optional): A set of headers that will be added to
@@ -67,7 +68,8 @@ def decode(token, key, algorithms=None, options=None, audience=None,
 
     Args:
         token (str): A signed JWS to be verified.
-        key (str): A key to attempt to verify the payload with.
+        key (str or dict): A key to attempt to verify the payload with. Can be
+            individual JWK or JWK set.
         algorithms (str or list): Valid algorithms that should be used to verify the JWS.
         audience (str): The intended audience of the token.  If the "aud" claim is
             included in the claim set, then the audience must be included and must equal


### PR DESCRIPTION
`_get_keys(key)` in `jws.py` allows for the `key` argument to already be in dictionary format. This PR updates comments to clarify for important functions.