### PR TITLE
Cryptographic backend isolation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,12 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea/
+
+# PyEnv
+.python-version
+
+# PyTest
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-pycryptodome
     - python: 2.7
-      env: TOXENV=py27-pycryptodome
+      env: TOXENV=py27-pycrypto
     - python: 2.7
       env: TOXENV=py27-compatibility
     # CPython 3.4
@@ -29,7 +29,7 @@ matrix:
     - python: 3.4
       env: TOXENV=py34-pycryptodome
     - python: 3.4
-      env: TOXENV=py34-pycryptodome
+      env: TOXENV=py34-pycrypto
     - python: 3.4
       env: TOXENV=py34-compatibility
     # CPython 3.5
@@ -40,7 +40,7 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-pycryptodome
     - python: 3.5
-      env: TOXENV=py35-pycryptodome
+      env: TOXENV=py35-pycrypto
     - python: 3.5
       env: TOXENV=py35-compatibility
     # CPython 3.5
@@ -51,7 +51,7 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-pycryptodome
     - python: 3.5
-      env: TOXENV=py35-pycryptodome
+      env: TOXENV=py35-pycrypto
     - python: 3.5
       env: TOXENV=py35-compatibility
     # PyPy 5.3.1
@@ -62,7 +62,7 @@ matrix:
     - python: pypy-5.3.1
       env: TOXENV=pypy-pycryptodome
     - python: pypy-5.3.1
-      env: TOXENV=pypy-pycryptodome
+      env: TOXENV=pypy-pycrypto
     - python: pypy-5.3.1
       env: TOXENV=pypy-compatibility
 # matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,70 @@
 # detail: https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
 dist: precise
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "pypy-5.3.1"
 install:
   - pip install -U setuptools && pip install -U tox codecov tox-travis
 script:
   - tox
 after_success:
   - codecov
+matrix:
+  include:
+    # CPython 2.7
+    - python: 2.7
+      env: TOXENV=py27-base
+    - python: 2.7
+      env: TOXENV=py27-cryptography
+    - python: 2.7
+      env: TOXENV=py27-pycryptodome
+    - python: 2.7
+      env: TOXENV=py27-pycryptodome
+    - python: 2.7
+      env: TOXENV=py27-compatibility
+    # CPython 3.4
+    - python: 3.4
+      env: TOXENV=py34-base
+    - python: 3.4
+      env: TOXENV=py34-cryptography
+    - python: 3.4
+      env: TOXENV=py34-pycryptodome
+    - python: 3.4
+      env: TOXENV=py34-pycryptodome
+    - python: 3.4
+      env: TOXENV=py34-compatibility
+    # CPython 3.5
+    - python: 3.5
+      env: TOXENV=py35-base
+    - python: 3.5
+      env: TOXENV=py35-cryptography
+    - python: 3.5
+      env: TOXENV=py35-pycryptodome
+    - python: 3.5
+      env: TOXENV=py35-pycryptodome
+    - python: 3.5
+      env: TOXENV=py35-compatibility
+    # CPython 3.5
+    - python: 3.5
+      env: TOXENV=py35-base
+    - python: 3.5
+      env: TOXENV=py35-cryptography
+    - python: 3.5
+      env: TOXENV=py35-pycryptodome
+    - python: 3.5
+      env: TOXENV=py35-pycryptodome
+    - python: 3.5
+      env: TOXENV=py35-compatibility
+    # PyPy 5.3.1
+    - python: pypy-5.3.1
+      env: TOXENV=pypy-base
+    - python: pypy-5.3.1
+      env: TOXENV=pypy-cryptography
+    - python: pypy-5.3.1
+      env: TOXENV=pypy-pycryptodome
+    - python: pypy-5.3.1
+      env: TOXENV=pypy-pycryptodome
+    - python: pypy-5.3.1
+      env: TOXENV=pypy-compatibility
 # matrix:
 #   include:
 #     - python: 3.6
-#       env:
-#         - TOX_ENV=flake8
-#       script: tox -e $TOX_ENV
+#       env: TOX_ENV=flake8

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -67,7 +67,7 @@ class CryptographyECKey(Key):
 
     def _process_jwk(self, jwk_dict):
         if not jwk_dict.get('kty') == 'EC':
-            raise JWKError("Incorrect key type.  Expected: 'EC', Recieved: %s" % jwk_dict.get('kty'))
+            raise JWKError("Incorrect key type.  Expected: 'EC', Received: %s" % jwk_dict.get('kty'))
 
         if not all(k in jwk_dict for k in ['x', 'y', 'crv']):
             raise JWKError('Mandatory parameters are missing')
@@ -212,7 +212,7 @@ class CryptographyRSAKey(Key):
 
     def _process_jwk(self, jwk_dict):
         if not jwk_dict.get('kty') == 'RSA':
-            raise JWKError("Incorrect key type.  Expected: 'RSA', Recieved: %s" % jwk_dict.get('kty'))
+            raise JWKError("Incorrect key type.  Expected: 'RSA', Received: %s" % jwk_dict.get('kty'))
 
         e = base64_to_long(jwk_dict.get('e', 256))
         n = base64_to_long(jwk_dict.get('n'))

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         'pytest',
         'pytest-cov',
         'pytest-runner',
-        'cryptography',
     ],
     install_requires=['six <2.0', 'ecdsa <1.0', 'rsa', 'future <1.0']
 )

--- a/tests/algorithms/test_EC_compat.py
+++ b/tests/algorithms/test_EC_compat.py
@@ -1,0 +1,33 @@
+import pytest
+
+try:
+    from jose.backends.ecdsa_backend import ECDSAECKey
+    from jose.backends.cryptography_backend import CryptographyECKey
+except ImportError:
+    ECDSAECKey = CryptographyECKey = None
+from jose.constants import ALGORITHMS
+
+from .test_EC import private_key
+
+
+@pytest.mark.backend_compatibility
+@pytest.mark.skipif(
+    None in (ECDSAECKey, CryptographyECKey),
+    reason="Multiple crypto backends not available for backend compatibility tests"
+)
+class TestBackendRsaCompatibility(object):
+
+    @pytest.mark.parametrize("BackendSign", [ECDSAECKey, CryptographyECKey])
+    @pytest.mark.parametrize("BackendVerify", [ECDSAECKey, CryptographyECKey])
+    def test_signing_parity(self, BackendSign, BackendVerify):
+        key_sign = BackendSign(private_key, ALGORITHMS.ES256)
+        key_verify = BackendVerify(private_key, ALGORITHMS.ES256).public_key()
+
+        msg = b'test'
+        sig = key_sign.sign(msg)
+
+        # valid signature
+        assert key_verify.verify(msg, sig)
+
+        # invalid signature
+        assert not key_verify.verify(msg, b'n' * 64)

--- a/tests/algorithms/test_RSA_compat.py
+++ b/tests/algorithms/test_RSA_compat.py
@@ -1,0 +1,50 @@
+import pytest
+
+try:
+    from jose.backends.rsa_backend import RSAKey as PurePythonRSAKey
+    from jose.backends.cryptography_backend import CryptographyRSAKey
+    from jose.backends.pycrypto_backend import RSAKey
+except ImportError:
+    PurePythonRSAKey = CryptographyRSAKey = RSAKey = None
+from jose.constants import ALGORITHMS
+
+from .test_RSA import private_key
+
+
+@pytest.mark.backend_compatibility
+@pytest.mark.skipif(
+    None in (PurePythonRSAKey, CryptographyRSAKey, RSAKey),
+    reason="Multiple crypto backends not available for backend compatibility tests"
+)
+class TestBackendRsaCompatibility(object):
+
+    @pytest.mark.parametrize("BackendSign", [RSAKey, CryptographyRSAKey, PurePythonRSAKey])
+    @pytest.mark.parametrize("BackendVerify", [RSAKey, CryptographyRSAKey, PurePythonRSAKey])
+    def test_signing_parity(self, BackendSign, BackendVerify):
+        key_sign = BackendSign(private_key, ALGORITHMS.RS256)
+        key_verify = BackendVerify(private_key, ALGORITHMS.RS256).public_key()
+
+        msg = b'test'
+        sig = key_sign.sign(msg)
+
+        # valid signature
+        assert key_verify.verify(msg, sig)
+
+        # invalid signature
+        assert not key_verify.verify(msg, b'n' * 64)
+
+    @pytest.mark.parametrize("BackendFrom", [RSAKey, CryptographyRSAKey, PurePythonRSAKey])
+    @pytest.mark.parametrize("BackendTo", [RSAKey, CryptographyRSAKey, PurePythonRSAKey])
+    def test_public_key_to_pem(self, BackendFrom, BackendTo):
+        key = BackendFrom(private_key, ALGORITHMS.RS256)
+        pubkey = key.public_key()
+
+        pkcs1_pub = pubkey.to_pem(pem_format='PKCS1').strip()
+        pkcs8_pub = pubkey.to_pem(pem_format='PKCS8').strip()
+        assert pkcs1_pub != pkcs8_pub, BackendFrom
+
+        pub1 = BackendTo(pkcs1_pub, ALGORITHMS.RS256)
+        pub8 = BackendTo(pkcs8_pub, ALGORITHMS.RS256)
+
+        assert pkcs8_pub == pub1.to_pem(pem_format='PKCS8').strip()
+        assert pkcs1_pub == pub8.to_pem(pem_format='PKCS1').strip()

--- a/tests/test_jwk.py
+++ b/tests/test_jwk.py
@@ -1,9 +1,7 @@
 from jose import jwk
 from jose.exceptions import JWKError
 from jose.backends.base import Key
-from jose.backends.pycrypto_backend import RSAKey
-from jose.backends.cryptography_backend import CryptographyECKey
-from jose.backends.ecdsa_backend import ECDSAECKey
+from jose.backends import ECKey, RSAKey
 
 import pytest
 
@@ -53,7 +51,7 @@ class TestJWK:
             key = RSAKey(rsa_key, 'HS512')
 
         with pytest.raises(JWKError):
-            key = ECDSAECKey(ec_key, 'RS512')  # noqa: F841
+            key = ECKey(ec_key, 'RS512')  # noqa: F841
 
     def test_invalid_jwk(self):
 
@@ -64,7 +62,7 @@ class TestJWK:
             key = RSAKey(hmac_key, 'RS256')
 
         with pytest.raises(JWKError):
-            key = ECDSAECKey(rsa_key, 'ES256')  # noqa: F841
+            key = ECKey(rsa_key, 'ES256')  # noqa: F841
 
     def test_RSAKey_errors(self):
 
@@ -104,9 +102,7 @@ class TestJWK:
         assert isinstance(key, jwk.Key)
 
     def test_construct_EC_from_jwk(self):
-        key = CryptographyECKey(ec_key, algorithm='ES512')
-        assert isinstance(key, jwk.Key)
-        key = ECDSAECKey(ec_key, algorithm='ES512')
+        key = ECKey(ec_key, algorithm='ES512')
         assert isinstance(key, jwk.Key)
 
     def test_construct_from_jwk_missing_alg(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,py}-{base,pyca,dome,pycrypto},flake8
+envlist = py{27,34,35,36,py}-{base,cryptography,pycryptodome,pycrypto,compatibility},flake8
 skip_missing_interpreters = True
 
 [testenv:basecommand]

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,39 @@
 [tox]
-envlist = py{27,34,35,36,py},flake8
+envlist = py{27,34,35,36,py}-{base,pyca,dome,pycrypto},flake8
 skip_missing_interpreters = True
 
-[testenv]
+[testenv:basecommand]
 commands =
     pip --version
-    py.test --cov-report term-missing --cov jose
+    py.test --cov-report term-missing --cov jose {posargs}
+
+[testenv:compatibility]
 deps =
-    six
-    future
-    pycrypto
-    ecdsa
+    cryptography
+    pycrypto >=2.6.0, <2.7.0
+    pycryptodome >=3.3.1, <4.0.0
+
+[testenv]
+deps =
     pytest
     pytest-cov
     pytest-runner
-    cryptography
+    compatibility: {[testenv:compatibility]deps}
+commands =
+    # Test the python-rsa backend
+    base: {[testenv:basecommand]commands} -m "not (cryptography or pycryptodome or pycrypto or backend_compatibility)"
+    # Test the pyca/cryptography backend
+    cryptography: {[testenv:basecommand]commands} -m "not (pycryptodome or pycrypto or backend_compatibility)"
+    # Test the pycryptodome backend
+    pycryptodome: {[testenv:basecommand]commands} -m "not (cryptography or pycrypto or backend_compatibility)"
+    # Test the pycrypto backend
+    pycrypto: {[testenv:basecommand]commands} -m "not (cryptography or pycryptodome or backend_compatibility)"
+    # Test cross-backend compatibility and coexistence
+    compatibility: {[testenv:basecommand]commands}
+extras =
+    cryptography: cryptography
+    pycryptodome: pycryptodome
+    pycrypto: pycrypto
 
 ; [testenv:flake8]
 ; commands = flake8 jose


### PR DESCRIPTION
As discussed in #108, this is the initial step in cryptographic backend isolation. This change adjusts the most test fixtures to use "whatever backend is available" and adds tox test environments that isolate the cryptographic backends to verify that all tests actually pass for all backends.

**NOTE:** As discussed in #108, some tests do fail as a result of this. Fixing _that_ is the next step.