### PR TITLE
Include docs and tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
 include README.rst
 include LICENSE
+include requirements.txt
+include requirements-*.txt
+include tox.ini
+graft docs
+graft tests


### PR DESCRIPTION
These are useful to downstreams, such as linux packagers.