### PR TITLE
enable `ES256K` for ECDSA signing scheme

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -27,7 +27,8 @@ class CryptographyECKey(Key):
         self.hash_alg = {
             ALGORITHMS.ES256: self.SHA256,
             ALGORITHMS.ES384: self.SHA384,
-            ALGORITHMS.ES512: self.SHA512
+            ALGORITHMS.ES512: self.SHA512,
+            ALGORITHMS.ES256K: self.SHA256
         }.get(algorithm)
         self._algorithm = algorithm
 

--- a/jose/backends/ecdsa_backend.py
+++ b/jose/backends/ecdsa_backend.py
@@ -26,6 +26,7 @@ class ECDSAECKey(Key):
         SHA256: ecdsa.curves.NIST256p,
         SHA384: ecdsa.curves.NIST384p,
         SHA512: ecdsa.curves.NIST521p,
+        SHA256: ecdsa.curves.SECP256k1,
     }
 
     def __init__(self, key, algorithm):
@@ -35,7 +36,8 @@ class ECDSAECKey(Key):
         self.hash_alg = {
             ALGORITHMS.ES256: self.SHA256,
             ALGORITHMS.ES384: self.SHA384,
-            ALGORITHMS.ES512: self.SHA512
+            ALGORITHMS.ES512: self.SHA512,
+            ALGORITHMS.ES256K: self.SHA256
         }.get(algorithm)
         self._algorithm = algorithm
 

--- a/jose/constants.py
+++ b/jose/constants.py
@@ -12,10 +12,11 @@ class Algorithms(object):
     ES256 = 'ES256'
     ES384 = 'ES384'
     ES512 = 'ES512'
+    ES256K = 'ES256K'
 
     HMAC = {HS256, HS384, HS512}
     RSA = {RS256, RS384, RS512}
-    EC = {ES256, ES384, ES512}
+    EC = {ES256, ES384, ES512, ES256K}
 
     SUPPORTED = HMAC.union(RSA).union(EC)
 
@@ -31,6 +32,7 @@ class Algorithms(object):
         ES256: hashlib.sha256,
         ES384: hashlib.sha384,
         ES512: hashlib.sha512,
+        ES256K: hashlib.sha256,
     }
 
     KEYS = {}

--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -72,6 +72,7 @@ def get_algorithm_object(algorithm):
         ALGORITHMS.ES256: 'SHA256',
         ALGORITHMS.ES384: 'SHA384',
         ALGORITHMS.ES512: 'SHA512',
+        ALGORITHMS.ES256K: 'SHA256',
     }
     key = get_key(algorithm)
     attr = algorithms.get(algorithm, None)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,6 @@ nose==1.3.6
 py==1.4.26
 pytest==2.7.0
 pytest-cov==1.8.1
-ecdsa==0.13
 wsgiref==0.1.2
 
 -r requirements.txt

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -322,6 +322,10 @@ class TestEC(object):
         token = jws.sign(payload, ec_private_key, algorithm=ALGORITHMS.ES512)
         assert jws.verify(token, ec_public_key, ALGORITHMS.ES512) == payload
 
+    def test_EC256K(self, payload):
+        token = jws.sign(payload, ec_private_key, algorithm=ALGORITHMS.ES256K)
+        assert jws.verify(token, ec_public_key, ALGORITHMS.ES256K) == payload
+
     def test_wrong_alg(self, payload):
         token = jws.sign(payload, ec_private_key, algorithm=ALGORITHMS.ES256)
         with pytest.raises(JWSError):


### PR DESCRIPTION
Ethereum, Bitcoin (and  uPort) use the secp256k1 curve for their signature scheme. To allow for JWT (and other JOSE schemes) handling in uPort, the `ES256K` algorithm has been added.

Additionally, `requirements-dev.txt` contained a redundant entry `ecdsa` causing a `pip install` to fail due to it being already listed in the chained `requirements.txt`.