### PR TITLE
fix CryptographyECKey.verify failure

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -101,8 +101,8 @@ class CryptographyECKey(Key):
 
     def verify(self, msg, sig):
         order = (2 ** self.prepared_key.curve.key_size) - 1
-        signature = sigencode_der(*sigdecode_string(sig, order), order=order)
         try:
+            signature = sigencode_der(*sigdecode_string(sig, order), order=order)
             self.prepared_key.verify(signature, msg, ec.ECDSA(self.hash_alg()))
             return True
         except Exception:


### PR DESCRIPTION
If an invalid signature is passed to `sigdecode_string`, an `AssertionError` is raise.
This assertion error was being passed up through `CryptographyECKey.verify`, rather
than `CryptographyECKey.verify` catching the error and returning False, as required
by the `Key.verify` API.

NOTE: This fixes the `pyca/cryptography` backend isolation tests, but the `base` and `compatibility` test runs are still expected to fail.