### PR TITLE
Remove pyca/cryptography backend's dependency on python-ecdsa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-base
     - python: 2.7
-      env: TOXENV=py27-cryptography
+      env: TOXENV=py27-cryptography-only
     - python: 2.7
       env: TOXENV=py27-pycryptodome
     - python: 2.7
@@ -25,7 +25,7 @@ matrix:
     - python: 3.4
       env: TOXENV=py34-base
     - python: 3.4
-      env: TOXENV=py34-cryptography
+      env: TOXENV=py34-cryptography-only
     - python: 3.4
       env: TOXENV=py34-pycryptodome
     - python: 3.4
@@ -36,7 +36,7 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-base
     - python: 3.5
-      env: TOXENV=py35-cryptography
+      env: TOXENV=py35-cryptography-only
     - python: 3.5
       env: TOXENV=py35-pycryptodome
     - python: 3.5
@@ -47,7 +47,7 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-base
     - python: 3.5
-      env: TOXENV=py35-cryptography
+      env: TOXENV=py35-cryptography-only
     - python: 3.5
       env: TOXENV=py35-pycryptodome
     - python: 3.5
@@ -58,7 +58,7 @@ matrix:
     - python: pypy-5.3.1
       env: TOXENV=pypy-base
     - python: pypy-5.3.1
-      env: TOXENV=pypy-cryptography
+      env: TOXENV=pypy-cryptography-only
     - python: pypy-5.3.1
       env: TOXENV=pypy-pycryptodome
     - python: pypy-5.3.1

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -1,5 +1,9 @@
 import six
-import ecdsa
+
+try:
+    from ecdsa import SigningKey as EcdsaSigningKey, VerifyingKey as EcdsaVerifyingKey
+except ImportError:
+    SigningKey = VerifyingKey = None
 from ecdsa.util import sigdecode_string, sigencode_string, sigdecode_der, sigencode_der
 
 from jose.backends.base import Key
@@ -37,7 +41,7 @@ class CryptographyECKey(Key):
             self.prepared_key = key
             return
 
-        if isinstance(key, (ecdsa.SigningKey, ecdsa.VerifyingKey)):
+        if None not in (EcdsaSigningKey, EcdsaVerifyingKey) and isinstance(key, (EcdsaSigningKey, EcdsaVerifyingKey)):
             # convert to PEM and let cryptography below load it as PEM
             key = key.to_pem().decode('utf-8')
 

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -104,7 +104,7 @@ class CryptographyECKey(Key):
 
         This is the number of bytes required to encode the maximum key value.
         """
-        return math.ceil(self.prepared_key.key_size / 8.0)
+        return int(math.ceil(self.prepared_key.key_size / 8.0))
 
     def _der_to_raw(self, der_signature):
         """Convert signature from DER encoding to RAW encoding."""

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -1,10 +1,13 @@
+from __future__ import division
+
+import math
+
 import six
 
 try:
     from ecdsa import SigningKey as EcdsaSigningKey, VerifyingKey as EcdsaVerifyingKey
 except ImportError:
-    SigningKey = VerifyingKey = None
-from ecdsa.util import sigdecode_string, sigencode_string, sigdecode_der, sigencode_der
+    EcdsaSigningKey = EcdsaVerifyingKey = None
 
 from jose.backends.base import Key
 from jose.utils import base64_to_long, long_to_base64
@@ -15,7 +18,9 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_private_key, load_pem_public_key
+from cryptography.utils import int_from_bytes, int_to_bytes
 from cryptography.x509 import load_pem_x509_certificate
 
 
@@ -94,15 +99,30 @@ class CryptographyECKey(Key):
         else:
             return public.public_key(self.cryptography_backend())
 
+    def _sig_component_length(self):
+        """Determine the correct serialization length for an encoded signature component.
+
+        This is the number of bytes required to encode the maximum key value.
+        """
+        return math.ceil(self.prepared_key.key_size / 8.0)
+
     def _der_to_asn1(self, der_signature):
         """Convert signature from DER encoding to ASN1 encoding."""
-        order = (2 ** self.prepared_key.curve.key_size) - 1
-        return sigencode_string(*sigdecode_der(der_signature, order), order=order)
+        r, s = decode_dss_signature(der_signature)
+        component_length = self._sig_component_length()
+        return int_to_bytes(r, component_length) + int_to_bytes(s, component_length)
 
     def _asn1_to_der(self, asn1_signature):
         """Convert signature from ASN1 encoding to DER encoding."""
-        order = (2 ** self.prepared_key.curve.key_size) - 1
-        return sigencode_der(*sigdecode_string(asn1_signature, order), order=order)
+        component_length = self._sig_component_length()
+        if len(asn1_signature) != int(2 * component_length):
+            raise ValueError("Invalid signature")
+
+        r_bytes = asn1_signature[:component_length]
+        s_bytes = asn1_signature[component_length:]
+        r = int_from_bytes(r_bytes, "big")
+        s = int_from_bytes(s_bytes, "big")
+        return encode_dss_signature(r, s)
 
     def sign(self, msg):
         if self.hash_alg.digest_size * 8 > self.prepared_key.curve.key_size:

--- a/tests/algorithms/test_EC.py
+++ b/tests/algorithms/test_EC.py
@@ -39,7 +39,7 @@ DER_SIGNATURE = (
     b"\x9d\xdf \xd1\xbc\xedK\x01\x87:}\xf2\x02!\x00\xb2shTA\x00\x1a\x13~\xba"
     b"J\xdb\xeem\x12\x1e\xfeMO\x04\xb2[\x86A\xbd\xc6hu\x953X\x1e"
 )
-ASN1_SIGNATURE = (
+RAW_SIGNATURE = (
     b"\x89yG\x81W\x01\x11\x9b0\x08\xa4\xd0\xe3g([\x07\xb5\x01\xb3\x9d\xdf "
     b"\xd1\xbc\xedK\x01\x87:}\xf2\xb2shTA\x00\x1a\x13~\xbaJ\xdb\xeem\x12\x1e"
     b"\xfeMO\x04\xb2[\x86A\xbd\xc6hu\x953X\x1e"
@@ -88,16 +88,16 @@ def test_cryptography_sig_component_length(algorithm, expected_length):
 
 @pytest.mark.cryptography
 @pytest.mark.skipif(CryptographyECKey is None, reason="pyca/cryptography backend not available")
-def test_cryptograhy_der_to_asn1():
+def test_cryptograhy_der_to_raw():
     key = CryptographyECKey(private_key, ALGORITHMS.ES256)
-    assert key._der_to_asn1(DER_SIGNATURE) == ASN1_SIGNATURE
+    assert key._der_to_raw(DER_SIGNATURE) == RAW_SIGNATURE
 
 
 @pytest.mark.cryptography
 @pytest.mark.skipif(CryptographyECKey is None, reason="pyca/cryptography backend not available")
-def test_cryptograhy_asn1_to_der():
+def test_cryptograhy_raw_to_der():
     key = CryptographyECKey(private_key, ALGORITHMS.ES256)
-    assert key._asn1_to_der(ASN1_SIGNATURE) == DER_SIGNATURE
+    assert key._raw_to_der(RAW_SIGNATURE) == DER_SIGNATURE
 
 
 class TestECAlgorithm:

--- a/tests/algorithms/test_EC.py
+++ b/tests/algorithms/test_EC.py
@@ -31,6 +31,18 @@ pNSsy11sIKmMl61YJzxvZ6WkNluBmkDPCQ==
 -----END EC PRIVATE KEY-----
 """
 
+# ES256 signatures generated to test conversion logic
+DER_SIGNATURE = (
+    b"0F\x02!\x00\x89yG\x81W\x01\x11\x9b0\x08\xa4\xd0\xe3g([\x07\xb5\x01\xb3"
+    b"\x9d\xdf \xd1\xbc\xedK\x01\x87:}\xf2\x02!\x00\xb2shTA\x00\x1a\x13~\xba"
+    b"J\xdb\xeem\x12\x1e\xfeMO\x04\xb2[\x86A\xbd\xc6hu\x953X\x1e"
+)
+ASN1_SIGNATURE = (
+    b"\x89yG\x81W\x01\x11\x9b0\x08\xa4\xd0\xe3g([\x07\xb5\x01\xb3\x9d\xdf "
+    b"\xd1\xbc\xedK\x01\x87:}\xf2\xb2shTA\x00\x1a\x13~\xbaJ\xdb\xeem\x12\x1e"
+    b"\xfeMO\x04\xb2[\x86A\xbd\xc6hu\x953X\x1e"
+)
+
 
 def _backend_exception_types():
     """Build the backend exception types based on available backends."""
@@ -49,6 +61,20 @@ def _backend_exception_types():
 def test_key_from_ecdsa():
     key = ecdsa.SigningKey.from_pem(private_key)
     assert not ECKey(key, ALGORITHMS.ES256).is_public()
+
+
+@pytest.mark.cryptography
+@pytest.mark.skipif(CryptographyECKey is None, reason="pyca/cryptography backend not available")
+def test_cryptograhy_der_to_asn1():
+    key = CryptographyECKey(private_key, ALGORITHMS.ES256)
+    assert key._der_to_asn1(DER_SIGNATURE) == ASN1_SIGNATURE
+
+
+@pytest.mark.cryptography
+@pytest.mark.skipif(CryptographyECKey is None, reason="pyca/cryptography backend not available")
+def test_cryptograhy_asn1_to_der():
+    key = CryptographyECKey(private_key, ALGORITHMS.ES256)
+    assert key._asn1_to_der(ASN1_SIGNATURE) == DER_SIGNATURE
 
 
 class TestECAlgorithm:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py{27,34,35,36,py}-{base,cryptography,pycryptodome,pycrypto,compatibility},flake8
+minversion = 3.4.0
+envlist =
+    py{27,34,35,36,py}-{base,cryptography-only,pycryptodome,pycrypto,compatibility},
+    flake8
 skip_missing_interpreters = True
 
 [testenv:basecommand]
@@ -19,6 +22,9 @@ deps =
     pytest-cov
     pytest-runner
     compatibility: {[testenv:compatibility]deps}
+commands_pre =
+    # Remove the python-rsa backend
+    only: pip uninstall -y ecdsa rsa
 commands =
     # Test the python-rsa backend
     base: {[testenv:basecommand]commands} -m "not (cryptography or pycryptodome or pycrypto or backend_compatibility)"


### PR DESCRIPTION
Previously, the `pyca/cryptography` backend was dependent on `python-ecdsa` to handle the conversion between DER encoded signatures and the raw signature encoding that JOSE uses.

This fixes that, using the DSS encoding/decoding utilities provided in `pyca/cryptography` and adding simplified raw signature encoding and decoding directly.

Also added in here are modifications to the tox and Travis CI configurations to remove `python-ecdsa` and `python-rsa` when testing the `pyca/cryptography` backend in isolation. This is a workaround until we can determine how best to remove those dependencies when the "cryptography" extras is selected.

NOTE: The `algorithms/test_RSA.py::test_cryptography_RSA_key_instance` test in the "compatibility" test runs will still fail. That is addressed separately in #116. The "base" test runs also still fail, as discussed in #114.