### PR TITLE
Address collections.abc import warning introduced in Python 3.7

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -3,7 +3,10 @@ import binascii
 import json
 import six
 
-from collections import Mapping, Iterable
+try:
+    from collections.abc import Mapping, Iterable  # Python 3
+except ImportError:
+    from collections import Mapping, Iterable  # Python 2, will be deprecated in Python 3.8
 
 from jose import jwk
 from jose.constants import ALGORITHMS

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -2,7 +2,10 @@
 import json
 
 from calendar import timegm
-from collections import Mapping
+try:
+    from collections.abc import Mapping  # Python3
+except ImportError:
+    from collections import Mapping  # Python2, will be depecrated in Python 3.8
 from datetime import datetime
 from datetime import timedelta
 from six import string_types

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,14 @@
 PyYAML==3.11
 cov-core==1.15.0
-coverage==3.7.1
-coveralls==0.5
+coverage==4.4
+coveralls==1.5.1
+cryptography==2.4.2
 docopt==0.6.2
 nose==1.3.6
-py==1.4.26
-pytest==2.7.0
-pytest-cov==1.8.1
-ecdsa==0.13
-wsgiref==0.1.2
-
+py==1.5.4
+pytest==4.1.1
+pytest-cov==2.6.1
+# wsgiref is included in python standard library in Python 3, and will fail to install.
+wsgiref==0.1.2; python_version < "3.0"
 -r requirements.txt
 -r requirements-rtd.txt


### PR DESCRIPTION
# Description
In Python 3.7, I am seeing the following warnings from this library:
```
  /usr/local/lib/python3.7/site-packages/jose/jwt.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping
  /usr/local/lib/python3.7/site-packages/jose/jws.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, Iterable
```
This warning was introduced in [this CPython commit](https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320).

To ensure future compatibility with Python 3.8, I've updated these imports to try importing from `collections.abc` and fall back to `collections` to keep backward compatibility with Python 2.

In addition, I made a few updates to the `requirements-dev.txt` that I needed to run the tests in Python 3.7. 
- Added conditional to only install `wsgiref` in Python 2, since it's not supported in Python 3 (and is instead included in the standard library)
- Removed `ecdsa` since it is a duplicate requirement from `requirements.txt` and pip complains
```
Double requirement given: ecdsa (from -r requirements.txt (line 5)) (already in ecdsa==0.13 (from -r requirements-dev.txt (line 10)), name='ecdsa')
```
- Updated `pytest`, `py`, `pytest-cov`, `coverage`, and `coveralls` packages to get tests to pass with Python 2 and 3.
- Added `cryptography` package required for tests.

# Testing
I created a virtualenv with both Python 2.7.14 and Python 3.7.1, ran `pip install -r requirements-dev.txt` and then ran the tests with `pytest tests`. Output below

### Python 2.7.14
```
(venv2) ➜  python-jose git:(master) ✗ pytest tests
================================================================================================================================= test session starts =================================================================================================================================
platform darwin -- Python 2.7.14, pytest-4.1.1, py-1.5.4, pluggy-0.8.1
rootdir: /Users/peteryin/code/open_source/python-jose, inifile: setup.cfg
plugins: cov-2.6.1
collected 184 items

tests/test_firebase.py ...                                                                                                                                                                                                                                                      [  1%]
tests/test_jwk.py .........                                                                                                                                                                                                                                                     [  6%]
tests/test_jws.py ......................................                                                                                                                                                                                                                        [ 27%]
tests/test_jwt.py .................................................                                                                                                                                                                                                             [ 53%]
tests/test_utils.py ..                                                                                                                                                                                                                                                          [ 54%]
tests/algorithms/test_EC.py .........................                                                                                                                                                                                                                           [ 68%]
tests/algorithms/test_HMAC.py ...                                                                                                                                                                                                                                               [ 70%]
tests/algorithms/test_RSA.py ..................................................                                                                                                                                                                                                 [ 97%]
tests/algorithms/test_base.py ..                                                                                                                                                                                                                                                [ 98%]
tests/rfc/test_rfc7520.py ...                                                                                                                                                                                                                                                   [100%]

================================================================================================================================== warnings summary ===================================================================================================================================
tests/test_jwt.py::TestJWT::test_invalid_claims_json
  /Users/peteryin/code/open_source/python-jose/tests/test_jwt.py:65: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(JWTError, message='Invalid payload string: ["a", "b"}'):

tests/test_jwt.py::TestJWT::test_invalid_claims
  /Users/peteryin/code/open_source/python-jose/tests/test_jwt.py:80: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(JWTError, message='Invalid payload string: must be a json object'):

-- Docs: https://docs.pytest.org/en/latest/warnings.html

---------- coverage: platform darwin, python 2.7.14-final-0 ----------
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
tests/__init__.py                   0      0   100%
tests/algorithms/__init__.py        0      0   100%
tests/algorithms/test_EC.py        79      0   100%
tests/algorithms/test_HMAC.py      32      0   100%
tests/algorithms/test_RSA.py      121      1    99%   17
tests/algorithms/test_base.py      11      0   100%
tests/rfc/__init__.py               0      0   100%
tests/rfc/test_rfc7520.py          20      0   100%
tests/test_firebase.py             12      0   100%
tests/test_jwk.py                  65      0   100%
tests/test_jws.py                 161      0   100%
tests/test_jwt.py                 286      0   100%
tests/test_utils.py                 9      0   100%
-------------------------------------------------------------
TOTAL                             796      1    99%

======================================================================================================================= 184 passed, 2 warnings in 12.12 seconds =======================================================================================================================
```
### Python 3.7.1
```
(venv3) ➜  python-jose git:(master) ✗ pytest tests
================================================================================================================================= test session starts =================================================================================================================================
platform darwin -- Python 3.7.1, pytest-4.1.1, py-1.5.4, pluggy-0.8.1
rootdir: /Users/peteryin/code/open_source/python-jose, inifile: setup.cfg
plugins: cov-2.6.1
collected 184 items

tests/test_firebase.py ...                                                                                                                                                                                                                                                      [  1%]
tests/test_jwk.py .........                                                                                                                                                                                                                                                     [  6%]
tests/test_jws.py ......................................                                                                                                                                                                                                                        [ 27%]
tests/test_jwt.py .................................................                                                                                                                                                                                                             [ 53%]
tests/test_utils.py ..                                                                                                                                                                                                                                                          [ 54%]
tests/algorithms/test_EC.py .........................                                                                                                                                                                                                                           [ 68%]
tests/algorithms/test_HMAC.py ...                                                                                                                                                                                                                                               [ 70%]
tests/algorithms/test_RSA.py ..................................................                                                                                                                                                                                                 [ 97%]
tests/algorithms/test_base.py ..                                                                                                                                                                                                                                                [ 98%]
tests/rfc/test_rfc7520.py ...                                                                                                                                                                                                                                                   [100%]

================================================================================================================================== warnings summary ===================================================================================================================================
tests/test_jwt.py::TestJWT::test_invalid_claims_json
  /Users/peteryin/code/open_source/python-jose/tests/test_jwt.py:65: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(JWTError, message='Invalid payload string: ["a", "b"}'):

tests/test_jwt.py::TestJWT::test_invalid_claims
  /Users/peteryin/code/open_source/python-jose/tests/test_jwt.py:80: PytestDeprecationWarning: The 'message' parameter is deprecated.
  (did you mean to use `match='some regex'` to check the exception message?)
  Please comment on https://github.com/pytest-dev/pytest/issues/3974 if you have concerns about removal of this parameter.
    with pytest.raises(JWTError, message='Invalid payload string: must be a json object'):

-- Docs: https://docs.pytest.org/en/latest/warnings.html

---------- coverage: platform darwin, python 3.7.1-final-0 -----------
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
tests/__init__.py                   0      0   100%
tests/algorithms/__init__.py        0      0   100%
tests/algorithms/test_EC.py        79      0   100%
tests/algorithms/test_HMAC.py      32      0   100%
tests/algorithms/test_RSA.py      121      0   100%
tests/algorithms/test_base.py      11      0   100%
tests/rfc/__init__.py               0      0   100%
tests/rfc/test_rfc7520.py          20      0   100%
tests/test_firebase.py             12      0   100%
tests/test_jwk.py                  65      0   100%
tests/test_jws.py                 161      0   100%
tests/test_jwt.py                 286      0   100%
tests/test_utils.py                 9      0   100%
-------------------------------------------------------------
TOTAL                             796      0   100%

======================================================================================================================= 184 passed, 2 warnings in 12.07 seconds =======================================================================================================================
```
There are some additional deprecation warnings that are coming from `pytest`, but I decided to stay conservative with the scope of this PR since it's my first contribution to this library. 