### PR TITLE
Prep backend-explicit-tests for merge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
 include README.rst
 include LICENSE
+include requirements.txt
+include requirements-*.txt
+include tox.ini
+graft docs
+graft tests

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -410,23 +410,27 @@ def _validate_jti(claims):
 
 def _validate_at_hash(claims, access_token, algorithm):
     """
-    Validates that the 'at_hash' parameter included in the claims matches
-    with the access_token returned alongside the id token as part of
-    the authorization_code flow.
+    Validates that the 'at_hash' is valid.
+
+    Its value is the base64url encoding of the left-most half of the hash
+    of the octets of the ASCII representation of the access_token value,
+    where the hash algorithm used is the hash algorithm used in the alg
+    Header Parameter of the ID Token's JOSE Header. For instance, if the
+    alg is RS256, hash the access_token value with SHA-256, then take the
+    left-most 128 bits and base64url encode them. The at_hash value is a
+    case sensitive string.  Use of this claim is OPTIONAL.
 
     Args:
-        claims (dict): The claims dictionary to validate.
-        access_token (str): The access token returned by the OpenID Provider.
-        algorithm (str): The algorithm used to sign the JWT, as specified by
-            the token headers.
+      claims (dict): The claims dictionary to validate.
+      access_token (str): The access token returned by the OpenID Provider.
+      algorithm (str): The algorithm used to sign the JWT, as specified by
+          the token headers.
     """
-    if 'at_hash' not in claims and not access_token:
+    if 'at_hash' not in claims:
         return
-    elif 'at_hash' in claims and not access_token:
+
+    if not access_token:
         msg = 'No access_token provided to compare against at_hash claim.'
-        raise JWTClaimsError(msg)
-    elif access_token and 'at_hash' not in claims:
-        msg = 'at_hash claim missing from token.'
         raise JWTClaimsError(msg)
 
     try:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -526,8 +526,8 @@ class TestJWT:
 
     def test_at_hash_missing_claim(self, claims, key):
         token = jwt.encode(claims, key)
-        with pytest.raises(JWTError):
-            jwt.decode(token, key, access_token='<ACCESS_TOKEN>')
+        payload = jwt.decode(token, key, access_token='<ACCESS_TOKEN>')
+        assert 'at_hash' not in payload
 
     def test_at_hash_unable_to_calculate(self, claims, key):
         token = jwt.encode(claims, key, access_token='<ACCESS_TOKEN>')


### PR DESCRIPTION
Given the relative number of changes, I figured it would be better to merge `master` into `backend-explicit-tests` first before merging `backend-explicit-tests` into `master`. That way the changes are smaller and more reviewable.

Next step from here will simply be merging `backend-explicit-tests` into `master`.