### PR TITLE
add initial versioning policy

### DIFF
--- a/VERSIONING.rst
+++ b/VERSIONING.rst
@@ -1,0 +1,7 @@
+----------
+Versioning
+----------
+
+Python-jose releases follow `Semantic Versioning`_.
+
+.. _Semantic Versioning: https://semver.org/


### PR DESCRIPTION
As discussed in #129, I would like to propose that python-jose officially state what versioning policy the project is following. While there seems to be tentative agreement that the project is following SemVer already, it would be great if that could be explicitly stated. This will make it much simpler for consumers of this library to reason about how to handle upgrades and will help the maintainers in deciding how changes should manifest in new versions.