### PR TITLE
Sort headers when serializing to allow for headless JWT.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Major
   `#121 <https://github.com/mpdavis/python-jose/pull/121>`_
 * Make pyca/cryptography backend the preferred backend if multiple backends are present.
   `#122 <https://github.com/mpdavis/python-jose/pull/122>`_
+* Allow for headless JWT by sorting headers when serializing.
+  `#136 <https://github.com/mpdavis/python-jose/pull/136>`_
 
 Bugfixes
 """"""""

--- a/jose/jws.py
+++ b/jose/jws.py
@@ -141,6 +141,7 @@ def _encode_header(algorithm, additional_headers=None):
     json_header = json.dumps(
         header,
         separators=(',', ':'),
+        sort_keys=True,
     ).encode('utf-8')
 
     return base64url_encode(json_header)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -107,6 +107,33 @@ class TestJWT:
         for k, v in headers.items():
             assert all_headers[k] == v
 
+    def test_deterministic_headers(self):
+        from collections import OrderedDict
+        from jose.utils import base64url_decode
+
+        claims = {"a": "b"}
+        key = "secret"
+
+        headers1 = OrderedDict((
+            ('kid', 'my-key-id'),
+            ('another_key', 'another_value'),
+        ))
+        encoded1 = jwt.encode(claims, key, algorithm='HS256', headers=headers1)
+        encoded_headers1 = encoded1.split('.', 1)[0]
+
+        headers2 = OrderedDict((
+            ('another_key', 'another_value'),
+            ('kid', 'my-key-id'),
+        ))
+        encoded2 = jwt.encode(claims, key, algorithm='HS256', headers=headers2)
+        encoded_headers2 = encoded2.split('.', 1)[0]
+
+        assert encoded_headers1 == encoded_headers2
+
+        # manually decode header to compare it to known good
+        decoded_headers1 = base64url_decode(encoded_headers1.encode('utf-8'))
+        assert decoded_headers1 == b"""{"alg":"HS256","another_key":"another_value","kid":"my-key-id","typ":"JWT"}"""
+
     def test_encode(self, claims, key):
 
         expected = (


### PR DESCRIPTION
Headers are usually small so this should not significantly impact
performance. Testing both equality between two serialized values (fails
on 3.6+ only) and equality with expected serialized JSON, which fails on pre 3.6
too.

This fixes #80 and is a less intrusive change than #81.