### PR TITLE
remove unused JWTSignatureError class

### DIFF
--- a/jose/exceptions.py
+++ b/jose/exceptions.py
@@ -24,10 +24,6 @@ class JWTClaimsError(JWTError):
     pass
 
 
-class JWTSignatureError(JWTError):
-    pass
-
-
 class ExpiredSignatureError(JWTError):
     pass
 


### PR DESCRIPTION
When a `JWSSignatureError` is raised, it is caught and reraised as a `JWSError`, which gets caught and reraised as a `JWTError`. The `JWTSignatureError` class is not used, so this pull request removes it.