### PR TITLE
Disallow verifying signatures with private RSA keys.

### DIFF
--- a/jose/backends/pycrypto_backend.py
+++ b/jose/backends/pycrypto_backend.py
@@ -147,6 +147,8 @@ class RSAKey(Key):
             raise JWKError(e)
 
     def verify(self, msg, sig):
+        if not self.is_public():
+            return False
         try:
             return PKCS1_v1_5.new(self.prepared_key).verify(self.hash_alg.new(msg), sig)
         except Exception:

--- a/jose/backends/rsa_backend.py
+++ b/jose/backends/rsa_backend.py
@@ -200,6 +200,8 @@ class RSAKey(Key):
         return pyrsa.sign(msg, self._prepared_key, self.hash_alg)
 
     def verify(self, msg, sig):
+        if not self.is_public():
+            return False
         try:
             pyrsa.verify(msg, sig, self._prepared_key)
             return True

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -291,6 +291,16 @@ class TestRSA(object):
         with pytest.raises(JWSError):
             jws.verify(token, rsa_public_key, ALGORITHMS.HS256)
 
+    def test_private_verify(self, payload):
+        token = jws.sign(payload, rsa_private_key, algorithm='RS256')
+
+        # verify with public
+        dec = jws.verify(token, rsa_public_key, algorithms='RS256')
+
+        with pytest.raises(JWSError):
+            # verify with private does not work
+            dec = jws.verify(token, rsa_private_key, algorithms='RS256')
+
 
 ec_private_key = """-----BEGIN EC PRIVATE KEY-----
 MIHcAgEBBEIBzs13YUnYbLfYXTz4SG4DE4rPmsL3wBTdy34JcO+BDpI+NDZ0pqam


### PR DESCRIPTION
Some backends are smart and know how to verify with private keys too.
Disallow that on those backends.

Backwards incompatible change.

Reported in #53.