### PR TITLE
Update allowed audience types described in docstring

### DIFF
--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -338,7 +338,7 @@ def _validate_aud(claims, audience=None):
 
     Args:
         claims (dict): The claims dictionary to validate.
-        audience (str): The audience that is verifying the token.
+        audience (str or list): The audience that is verifying the token.
     """
 
     if 'aud' not in claims:


### PR DESCRIPTION
The type for audience is listed as `str`, but clearly `list` is accepted as well.