### PR TITLE
Fix logic error in _validate_exp()

### DIFF
--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -317,7 +317,7 @@ def _validate_exp(claims, leeway=0):
 
     now = timegm(datetime.utcnow().utctimetuple())
 
-    if exp < (now - leeway):
+    if exp < (now + leeway):
         raise ExpiredSignatureError('Signature has expired.')
 
 


### PR DESCRIPTION
The `leeway` has to be added to `now` b/c the logic is “raise an error if the token expires in `now + leeway`”.