### PR TITLE
Remove constant_time_string_compare

### DIFF
--- a/jose/jwk.py
+++ b/jose/jwk.py
@@ -6,7 +6,6 @@ import six
 from jose.constants import ALGORITHMS
 from jose.exceptions import JWKError
 from jose.utils import base64url_decode, base64url_encode
-from jose.utils import constant_time_string_compare
 from jose.backends.base import Key
 
 try:
@@ -135,7 +134,7 @@ class HMACKey(Key):
         return hmac.new(self.prepared_key, msg, self.hash_alg).digest()
 
     def verify(self, msg, sig):
-        return constant_time_string_compare(sig, self.sign(msg))
+        return hmac.compare_digest(sig, self.sign(msg))
 
     def to_dict(self):
         return {

--- a/jose/utils.py
+++ b/jose/utils.py
@@ -108,27 +108,3 @@ def timedelta_total_seconds(delta):
         delta (timedelta): A timedelta to convert to seconds.
     """
     return delta.days * 24 * 60 * 60 + delta.seconds
-
-
-def constant_time_string_compare(a, b):
-    """Helper for comparing string in constant time, independent
-    of the python version being used.
-
-    Args:
-        a (str): A string to compare
-        b (str): A string to compare
-    """
-
-    try:
-        return hmac.compare_digest(a, b)
-    except AttributeError:
-
-        if len(a) != len(b):
-            return False
-
-        result = 0
-
-        for x, y in zip(a, b):
-            result |= ord(x) ^ ord(y)
-
-        return result == 0


### PR DESCRIPTION
The `hmac.compare_digest` function was [added in Python 2.7](https://docs.python.org/2/library/hmac.html#hmac.compare_digest), which is the minimum that we support. We no longer need this compatibility shim.