### PR TITLE
Allow audience claim to be one of a list

### DIFF
--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -479,9 +479,6 @@ def _validate_claims(claims, audience=None, issuer=None, subject=None,
         else:
             options['verify_' + require_claim] = True  # override verify when required
 
-    if not isinstance(audience, (string_types, type(None))):
-        raise JWTError('audience must be a string or None')
-
     if options.get('verify_iat'):
         _validate_iat(claims)
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -366,6 +366,42 @@ class TestJWT:
         token = jwt.encode(claims, key)
         jwt.decode(token, key, audience=aud)
 
+    def test_aud_list_without_matches(self, key):
+
+        aud = 'audience'
+
+        claims = {
+            'aud': ['one audience', 'another audience']
+        }
+
+        token = jwt.encode(claims, key)
+        with pytest.raises(JWTError):
+            jwt.decode(token, key, audience=aud)
+
+    def test_aud_list_is_empty(self, key):
+
+        aud = 'audience'
+
+        claims = {
+            'aud': []
+        }
+
+        token = jwt.encode(claims, key)
+        with pytest.raises(JWTError):
+            jwt.decode(token, key, audience=aud)
+
+    def test_aud_list_is_not_none(self, key):
+
+        aud = 'audience'
+
+        claims = {
+            'aud': [aud, None]
+        }
+
+        token = jwt.encode(claims, key)
+        with pytest.raises(JWTError):
+            jwt.decode(token, key, audience=aud)
+
     def test_aud_list_is_strings(self, key):
 
         aud = 'audience'
@@ -412,6 +448,18 @@ class TestJWT:
     def test_aud_given_number(self, key):
 
         aud = 'audience'
+
+        claims = {
+            'aud': aud
+        }
+
+        token = jwt.encode(claims, key)
+        with pytest.raises(JWTError):
+            jwt.decode(token, key, audience=1)
+
+    def test_aud_not_string_or_list_given_number(self, key):
+
+        aud = 1
 
         claims = {
             'aud': aud


### PR DESCRIPTION
This PR removes a poorly placed, redundant, and overly restrictive type check for the `aud` claim, so `aud` claims can be a list of strings.

I also added a few more tests for `aud` claims and the `audience` keyword parameter to `JWT.decode` to make sure I didn't allow for improper behavior.

~Closes #148.~

Edit: May not close #148 after all, because that might be invalid.