### PR TITLE
Avoid loading python-ecdsa when using the cryptography backend

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -4,11 +4,6 @@ import math
 
 import six
 
-try:
-    from ecdsa import SigningKey as EcdsaSigningKey, VerifyingKey as EcdsaVerifyingKey
-except ImportError:
-    EcdsaSigningKey = EcdsaVerifyingKey = None
-
 from jose.backends.base import Key
 from jose.utils import base64_to_long, long_to_base64
 from jose.constants import ALGORITHMS
@@ -46,7 +41,7 @@ class CryptographyECKey(Key):
             self.prepared_key = key
             return
 
-        if None not in (EcdsaSigningKey, EcdsaVerifyingKey) and isinstance(key, (EcdsaSigningKey, EcdsaVerifyingKey)):
+        if hasattr(key, 'to_pem'):
             # convert to PEM and let cryptography below load it as PEM
             key = key.to_pem().decode('utf-8')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycryptodome
 six
 rsa
-ecdsa
+ecdsa<0.15
 pyasn1

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
     'pycrypto': ['pycrypto >=2.6.0, <2.7.0'] + pyasn1,
     'pycryptodome': ['pycryptodome >=3.3.1, <4.0.0'] + pyasn1,
 }
-legacy_backend_requires = ['ecdsa <1.0', 'rsa'] + pyasn1
+legacy_backend_requires = ['ecdsa <0.15', 'rsa'] + pyasn1
 install_requires = ['six <2.0']
 
 # TODO: work this into the extras selection instead.

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ deps =
     pytest
     pytest-cov
     pytest-runner
+    -r{toxinidir}/requirements.txt
+
 commands_pre =
     # Remove the python-rsa and python-ecdsa backends
     only: pip uninstall -y ecdsa rsa


### PR DESCRIPTION
In #117 dependency on `ecdsa` cryptography backend was removed, however it is still loaded even when not used.  Since `ecdsa` has a load time performance penalty when `gmpy2` is not installed, this can be a bit painful on embedded systems.

We can avoid all this overhead and check to see if the key object hasattr `to_pem` instead since we only
care of these if `ecdsa` has already been loaded by something else.