### PR TITLE
Update and expand tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Travis infra requires pinning dist:precise, at least as of 2017-09-01
 # detail: https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
-dist: precise
+dist: bionic
 language: python
 install:
   - pip install -U setuptools && pip install -U tox codecov tox-travis
@@ -47,28 +47,16 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-compatibility
     # CPython 3.7
-    # xenial + sudo are currently needed to get 3.7
-    # https://github.com/travis-ci/travis-ci/issues/9815
     - python: 3.7
       env: TOXENV=py37-base
-      dist: xenial
-      sudo: true
     - python: 3.7
       env: TOXENV=py37-cryptography-only
-      dist: xenial
-      sudo: true
     - python: 3.7
       env: TOXENV=py37-pycryptodome-norsa
-      dist: xenial
-      sudo: true
     - python: 3.7
       env: TOXENV=py37-pycrypto-norsa
-      dist: xenial
-      sudo: true
     - python: 3.7
       env: TOXENV=py37-compatibility
-      dist: xenial
-      sudo: true
     # PyPy 3.5 (5.10.1?)
     - python: pypy3.5
       env: TOXENV=pypy-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ script:
   - tox
 after_success:
   - codecov
+jobs:
+  allow_failures:
+  - python: 3.9-dev
 matrix:
   include:
     # Linting
@@ -57,14 +60,47 @@ matrix:
       env: TOXENV=py37-pycrypto-norsa
     - python: 3.7
       env: TOXENV=py37-compatibility
-    # PyPy 3.5 (5.10.1?)
-    - python: pypy3.5
+    # CPython 3.8
+    - python: 3.8
+      env: TOXENV=py38-base
+    - python: 3.8
+      env: TOXENV=py38-cryptography-only
+    - python: 3.8
+      env: TOXENV=py38-pycryptodome-norsa
+    - python: 3.8
+      env: TOXENV=py38-pycrypto-norsa
+    - python: 3.8
+      env: TOXENV=py38-compatibility
+    # CPython 3.9 - dev
+    - python: 3.9-dev
+      env: TOXENV=py39-base
+    - python: 3.9-dev
+      env: TOXENV=py39-cryptography-only
+    - python: 3.9-dev
+      env: TOXENV=py39-pycryptodome-norsa
+    - python: 3.9-dev
+      env: TOXENV=py39-pycrypto-norsa
+    - python: 3.9-dev
+      env: TOXENV=py39-compatibility
+    # PyPy 2.7
+    - python: pypy2
       env: TOXENV=pypy-base
-    - python: pypy3.5
+    - python: pypy2
       env: TOXENV=pypy-cryptography-only
-    - python: pypy3.5
+    - python: pypy2
       env: TOXENV=pypy-pycryptodome-norsa
-    - python: pypy3.5
+    - python: pypy2
       env: TOXENV=pypy-pycrypto-norsa
-    - python: pypy3.5
+    - python: pypy2
       env: TOXENV=pypy-compatibility
+    # PyPy 3.x
+    - python: pypy3
+      env: TOXENV=pypy-base
+    - python: pypy3
+      env: TOXENV=pypy3-cryptography-only
+    - python: pypy3
+      env: TOXENV=pypy3-pycryptodome-norsa
+    - python: pypy3
+      env: TOXENV=pypy3-pycrypto-norsa
+    - python: pypy3
+      env: TOXENV=pypy3-compatibility

--- a/jose/backends/__init__.py
+++ b/jose/backends/__init__.py
@@ -4,6 +4,16 @@ try:
 except ImportError:
     try:
         from jose.backends.pycrypto_backend import RSAKey  # noqa: F401
+
+        # time.clock was deprecated in python 3.3 in favor of time.perf_counter
+        # and removed in python 3.8. pycrypto was never updated for this. If
+        # time has no clock attribute, let it use perf_counter instead to work
+        # in 3.8+
+        # noinspection PyUnresolvedReferences
+        import time
+        if not hasattr(time, "clock"):
+            time.clock = time.perf_counter
+
     except ImportError:
         from jose.backends.rsa_backend import RSAKey  # noqa: F401
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cryptography==2.4.2
 docopt==0.6.2
 nose==1.3.6
 py==1.5.4
-pytest==4.1.1
+pytest==4.6.10
 pytest-cov==2.6.1
 # wsgiref is included in python standard library in Python 3, and will fail to install.
 wsgiref==0.1.2; python_version < "3.0"

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
     ],

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     ],
     tests_require=[
         'six',
-        'ecdsa',
+        'ecdsa<0.15',
         'pytest',
         'pytest-cov',
         'pytest-runner',

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,12 @@ commands =
     pip --version
     py.test --cov-report term-missing --cov jose {posargs}
 
+[testenv:pypy-compatibility]
+# This testenv locks up during coverage so just run tests
+commands =
+    pip --version
+    py.test
+
 [testenv:compatibility]
 extras =
     cryptography

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,12 @@ commands =
     pip --version
     py.test
 
+[testenv:pypy3-compatibility]
+# This testenv locks up during coverage so just run tests
+commands =
+    pip --version
+    py.test
+
 [testenv:compatibility]
 extras =
     cryptography

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ deps =
     pytest
     pytest-cov
     pytest-runner
-    -r{toxinidir}/requirements.txt
 
 commands_pre =
     # Remove the python-rsa and python-ecdsa backends

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,10 @@ extras =
     pycryptodome: pycryptodome
     pycrypto: pycrypto
     compatibility: {[testenv:compatibility]extras}
+setenv =
+    # pycrypto does not reliably build if GMP is installed and used so disable it
+    pypy: with_gmp=no
+    pypy3: with_gmp=no
 
 [testenv:flake8]
 skip_install= True

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ setenv =
     pypy3: with_gmp=no
 
 [testenv:flake8]
+basepython = python3.6
 skip_install= True
 deps =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.4.0
 envlist =
-    py{27,35,36,py}-{base,cryptography-only,pycryptodome-norsa,pycrypto-norsa,compatibility},
+    py{27,35,36,37,38,39,py,py3}-{base,cryptography-only,pycryptodome-norsa,pycrypto-norsa,compatibility},
     flake8
 skip_missing_interpreters = True
 


### PR DESCRIPTION
This PR pulls the updates to the test code out of PR #181 and breaks the changes into multiple commits:

* Pin `ecdsa < 0.15` in `test_requires` in `setup.py`
* Update pytest to 4.6.10
* Skip installing GMP for Pypy and Pypy3 tests - this fixes tests stalling in `test_RSA.py`
* Advertise support for Python 3.8
* Fix `time.clock` removal for Python 3.8+
* Use the Ubuntu Bionic image on Travis
* Add py27, py37, py38, py39, pypy, and pypy3 tox environments
* Add Python 3.8 and 3.9-dev to the Travis build matrix (3.9-dev tests are allowed to fail)
* Specify the `basepython = 3.6` for the `flake8` environment in the tox config, to match the Travis environment
* Don't install requirements from `requirements.txt` in tox - tox should do that automatically

Since all of these changes only tweak the way tests are run, I'll create an additional PR for the rest of the changes in #181.