### PR TITLE
Made json.loads process numbers as strings; closes #45

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -225,7 +225,7 @@ def _sig_matches_keys(keys, signing_input, signature, alg):
 def _get_keys(key):
 
     try:
-        key = json.loads(key)
+        key = json.loads(key, parse_int=str, parse_float=str)
     except Exception:
         pass
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -52,6 +52,13 @@ class TestJWT:
                 key=key,
                 algorithms=[])
 
+    @pytest.mark.parametrize("key, token",
+                             [('1234567890', u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCJ9.aNBlulVhiYSCzvsh1rTzXZC2eWJmNrMBjINT-0wQz4k'),
+                              ('123456789.0',u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCJ9.D8WLFPMi3yKgua2jm3BKThFsParXpgxhIbsUc39zJDw')])
+    def test_numeric_key(self, key, token):
+        token_info = jwt.decode(token, key)
+        assert token_info == {"name": "test"}
+
     def test_invalid_claims_json(self):
         old_jws_verify = jws.verify
         try:


### PR DESCRIPTION
This PR closes issue #45, specifically the issue with numeric keys (which couldn't be string with only integers, as 1234567890, or floats, as 123456789.0)

Added two test cases that decode JWT tokens signed with the referred keys. All existing test cases passed. 