### PR TITLE
Allow bytes secret

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -229,24 +229,23 @@ def _get_keys(key):
     except Exception:
         pass
 
-    # JWK Set per RFC 7517
-    if 'keys' in key:
-        return key['keys']
-
-    # Individual JWK per RFC 7517
-    elif 'kty' in key:
-        return (key,)
-
-    # Some other mapping. Firebase uses just dict of kid, cert pairs
-    elif isinstance(key, Mapping):
-        values = key.values()
-        if values:
-            return values
-        return (key,)
+    if isinstance(key, Mapping):
+        if 'keys' in key:
+            # JWK Set per RFC 7517
+            return key['keys']
+        elif 'kty' in key:
+            # Individual JWK per RFC 7517
+            return (key,)
+        else:
+            # Some other mapping. Firebase uses just dict of kid, cert pairs
+            values = key.values()
+            if values:
+                return values
+            return (key,)
 
     # Iterable but not text or mapping => list- or tuple-like
     elif (isinstance(key, Iterable) and
-          not (isinstance(key, six.string_types) or isinstance(key, Mapping))):
+          not (isinstance(key, six.string_types) or isinstance(key, six.binary_type))):
         return key
 
     # Scalar value, wrap in tuple.

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -77,6 +77,17 @@ class TestJWS(object):
         with pytest.raises(JWSError):
             jws.sign(payload, 'secret', algorithm='RS256')
 
+    @pytest.mark.parametrize("key", [
+        b'key',
+        'key',
+    ])
+    def test_round_trip_with_different_key_types(self, key):
+        signed_data = jws.sign({'testkey': 'testvalue'}, key, algorithm=ALGORITHMS.HS256)
+        verified_bytes = jws.verify(signed_data, key, algorithms=[ALGORITHMS.HS256])
+        verified_data = json.loads(verified_bytes.decode('utf-8'))
+        assert 'testkey' in verified_data.keys()
+        assert verified_data['testkey'] == 'testvalue'
+
 
 class TestHMAC(object):
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -165,6 +165,16 @@ class TestJWT:
 
         assert decoded == claims
 
+    @pytest.mark.parametrize('key', [
+        b'key',
+        'key',
+    ])
+    def test_round_trip_with_different_key_types(self, key):
+        token = jwt.encode({'testkey': 'testvalue'}, key, algorithm='HS256')
+        verified_data = jwt.decode(token, key, algorithms=['HS256'])
+        assert 'testkey' in verified_data.keys()
+        assert verified_data['testkey'] == 'testvalue'
+
     def test_leeway_is_int(self):
         pass
 


### PR DESCRIPTION
Closes #71.
Resolves #72.
Resolves #74.
Closes #93 (supercedes).
Resolves #126.

This PR makes key handling more robust by properly handling keys that are dictionaries and (more importantly) keys that are _not_ dictionaries.