### PR TITLE
Fix JWS verify

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -208,15 +208,15 @@ class CryptographyECKey(Key):
             'alg': self._algorithm,
             'kty': 'EC',
             'crv': crv,
-            'x': long_to_base64(public_key.public_numbers().x, size=key_size).decode('ASCII'),
-            'y': long_to_base64(public_key.public_numbers().y, size=key_size).decode('ASCII'),
+            'x': long_to_base64(public_key.public_numbers().x, size=key_size).decode('utf-8'),
+            'y': long_to_base64(public_key.public_numbers().y, size=key_size).decode('utf-8'),
         }
 
         if not self.is_public():
             data['d'] = long_to_base64(
                 self.prepared_key.private_numbers().private_value,
                 size=key_size
-            ).decode('ASCII')
+            ).decode('utf-8')
 
         return data
 
@@ -393,18 +393,18 @@ class CryptographyRSAKey(Key):
         data = {
             'alg': self._algorithm,
             'kty': 'RSA',
-            'n': long_to_base64(public_key.public_numbers().n).decode('ASCII'),
-            'e': long_to_base64(public_key.public_numbers().e).decode('ASCII'),
+            'n': long_to_base64(public_key.public_numbers().n).decode('utf-8'),
+            'e': long_to_base64(public_key.public_numbers().e).decode('utf-8'),
         }
 
         if not self.is_public():
             data.update({
-                'd': long_to_base64(self.prepared_key.private_numbers().d).decode('ASCII'),
-                'p': long_to_base64(self.prepared_key.private_numbers().p).decode('ASCII'),
-                'q': long_to_base64(self.prepared_key.private_numbers().q).decode('ASCII'),
-                'dp': long_to_base64(self.prepared_key.private_numbers().dmp1).decode('ASCII'),
-                'dq': long_to_base64(self.prepared_key.private_numbers().dmq1).decode('ASCII'),
-                'qi': long_to_base64(self.prepared_key.private_numbers().iqmp).decode('ASCII'),
+                'd': long_to_base64(self.prepared_key.private_numbers().d).decode('utf-8'),
+                'p': long_to_base64(self.prepared_key.private_numbers().p).decode('utf-8'),
+                'q': long_to_base64(self.prepared_key.private_numbers().q).decode('utf-8'),
+                'dp': long_to_base64(self.prepared_key.private_numbers().dmp1).decode('utf-8'),
+                'dq': long_to_base64(self.prepared_key.private_numbers().dmq1).decode('utf-8'),
+                'qi': long_to_base64(self.prepared_key.private_numbers().iqmp).decode('utf-8'),
             })
 
         return data
@@ -610,7 +610,7 @@ class CryptographyHMACKey(Key):
         return {
             'alg': self._algorithm,
             'kty': 'oct',
-            'k': base64url_encode(self.prepared_key).decode('ASCII'),
+            'k': base64url_encode(self.prepared_key).decode('utf-8'),
         }
 
     def sign(self, msg):

--- a/jose/backends/ecdsa_backend.py
+++ b/jose/backends/ecdsa_backend.py
@@ -131,14 +131,14 @@ class ECDSAECKey(Key):
             'alg': self._algorithm,
             'kty': 'EC',
             'crv': crv,
-            'x': long_to_base64(public_key.pubkey.point.x(), size=key_size).decode('ASCII'),
-            'y': long_to_base64(public_key.pubkey.point.y(), size=key_size).decode('ASCII'),
+            'x': long_to_base64(public_key.pubkey.point.x(), size=key_size).decode('utf-8'),
+            'y': long_to_base64(public_key.pubkey.point.y(), size=key_size).decode('utf-8'),
         }
 
         if not self.is_public():
             data['d'] = long_to_base64(
                 self.prepared_key.privkey.secret_multiplier,
                 size=key_size
-            ).decode('ASCII')
+            ).decode('utf-8')
 
         return data

--- a/jose/backends/native.py
+++ b/jose/backends/native.py
@@ -76,5 +76,5 @@ class HMACKey(Key):
         return {
             'alg': self._algorithm,
             'kty': 'oct',
-            'k': base64url_encode(self.prepared_key).decode('ASCII'),
+            'k': base64url_encode(self.prepared_key).decode('utf-8'),
         }

--- a/jose/backends/pycrypto_backend.py
+++ b/jose/backends/pycrypto_backend.py
@@ -206,8 +206,8 @@ class RSAKey(Key):
         data = {
             'alg': self._algorithm,
             'kty': 'RSA',
-            'n': long_to_base64(self.prepared_key.n).decode('ASCII'),
-            'e': long_to_base64(self.prepared_key.e).decode('ASCII'),
+            'n': long_to_base64(self.prepared_key.n).decode('utf-8'),
+            'e': long_to_base64(self.prepared_key.e).decode('utf-8'),
         }
 
         if not self.is_public():
@@ -222,12 +222,12 @@ class RSAKey(Key):
             dp = self.prepared_key.d % (self.prepared_key.p - 1)
             dq = self.prepared_key.d % (self.prepared_key.q - 1)
             data.update({
-                'd': long_to_base64(self.prepared_key.d).decode('ASCII'),
-                'p': long_to_base64(self.prepared_key.q).decode('ASCII'),
-                'q': long_to_base64(self.prepared_key.p).decode('ASCII'),
-                'dp': long_to_base64(dq).decode('ASCII'),
-                'dq': long_to_base64(dp).decode('ASCII'),
-                'qi': long_to_base64(self.prepared_key.u).decode('ASCII'),
+                'd': long_to_base64(self.prepared_key.d).decode('utf-8'),
+                'p': long_to_base64(self.prepared_key.q).decode('utf-8'),
+                'q': long_to_base64(self.prepared_key.p).decode('utf-8'),
+                'dp': long_to_base64(dq).decode('utf-8'),
+                'dq': long_to_base64(dp).decode('utf-8'),
+                'qi': long_to_base64(self.prepared_key.u).decode('utf-8'),
             })
 
         return data

--- a/jose/backends/rsa_backend.py
+++ b/jose/backends/rsa_backend.py
@@ -256,18 +256,18 @@ class RSAKey(Key):
         data = {
             'alg': self._algorithm,
             'kty': 'RSA',
-            'n': long_to_base64(public_key.n).decode('ASCII'),
-            'e': long_to_base64(public_key.e).decode('ASCII'),
+            'n': long_to_base64(public_key.n).decode('utf-8'),
+            'e': long_to_base64(public_key.e).decode('utf-8'),
         }
 
         if not self.is_public():
             data.update({
-                'd': long_to_base64(self._prepared_key.d).decode('ASCII'),
-                'p': long_to_base64(self._prepared_key.p).decode('ASCII'),
-                'q': long_to_base64(self._prepared_key.q).decode('ASCII'),
-                'dp': long_to_base64(self._prepared_key.exp1).decode('ASCII'),
-                'dq': long_to_base64(self._prepared_key.exp2).decode('ASCII'),
-                'qi': long_to_base64(self._prepared_key.coef).decode('ASCII'),
+                'd': long_to_base64(self._prepared_key.d).decode('utf-8'),
+                'p': long_to_base64(self._prepared_key.p).decode('utf-8'),
+                'q': long_to_base64(self._prepared_key.q).decode('utf-8'),
+                'dp': long_to_base64(self._prepared_key.exp1).decode('utf-8'),
+                'dq': long_to_base64(self._prepared_key.exp2).decode('utf-8'),
+                'qi': long_to_base64(self._prepared_key.coef).decode('utf-8'),
             })
 
         return data

--- a/jose/jwe.py
+++ b/jose/jwe.py
@@ -44,9 +44,11 @@ def encrypt(plaintext, key, encryption=ALGORITHMS.A256GCM,
         JWEError: If there is an error signing the token.
 
     Examples:
+
         >>> from jose import jwe
-        >>> jwe.encrypt('Hello, World!', 'asecret128bitkey', algorithm='dir', encryption='A128GCM')
-        'eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..McILMB3dYsNJSuhcDzQshA.OfX9H_mcUpHDeRM4IA.CcnTWqaqxNsjT4eCaUABSg'
+        >>> jwe_string = jwe.encrypt('Hello, World!', 'asecret128bitkey', algorithm='dir', encryption='A128GCM')
+        >>> jwe_string
+        'eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0...'
 
     """
     plaintext = six.ensure_binary(plaintext)  # Make sure it's bytes
@@ -80,9 +82,13 @@ def decrypt(jwe_str, key):
         JWEError: If there is an exception verifying the token.
 
     Examples:
+
         >>> from jose import jwe
+        >>> jwe_string = ('eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..McILMB3dYsNJSuhcDzQshA.'
+        ...               'OfX9H_mcUpHDeRM4IA.CcnTWqaqxNsjT4eCaUABSg')
         >>> jwe.decrypt(jwe_string, 'asecret128bitkey')
         'Hello, World!'
+
     """
     header, encoded_header, encrypted_key, iv, cipher_text, auth_tag = _jwe_compact_deserialize(jwe_str)
 
@@ -208,6 +214,15 @@ def get_unverified_header(jwe_str):
 
     Raises:
         JWEError: If there is an exception decoding the JWE.
+
+    Examples:
+
+        >>> from jose import jwe
+        >>> jwe_string = ('eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..McILMB3dYsNJSuhcDzQshA.'
+        ...               'OfX9H_mcUpHDeRM4IA.CcnTWqaqxNsjT4eCaUABSg')
+        >>> jwe.get_unverified_header(jwe_string)
+        {'alg': 'dir', 'enc': 'A128GCM'}
+
     """
     header = _jwe_compact_deserialize(jwe_str)[0]
     return header

--- a/jose/jwe.py
+++ b/jose/jwe.py
@@ -61,9 +61,8 @@ def encrypt(plaintext, key, encryption=ALGORITHMS.A256GCM,
     enc_cek, iv, cipher_text, auth_tag = _encrypt_and_auth(
         key, algorithm, encryption, zip, plaintext, encoded_header)
 
-    jwe_string = _jwe_compact_serialize(
-        encoded_header, enc_cek, iv, cipher_text, auth_tag)
-    return jwe_string
+    jwe_string = _jwe_compact_serialize(encoded_header, enc_cek, iv, cipher_text, auth_tag)
+    return jwe_string.decode('utf-8')
 
 
 def decrypt(jwe_str, key):
@@ -195,7 +194,7 @@ def decrypt(jwe_str, key):
     if plain_text is not None:
         plain_text = _decompress(header.get("zip"), plain_text)
 
-    return plain_text if cek_valid else None
+    return plain_text.decode('utf-8') if cek_valid else None
 
 
 def get_unverified_header(jwe_str):

--- a/jose/jwe.py
+++ b/jose/jwe.py
@@ -22,7 +22,7 @@ def encrypt(plaintext, key, encryption=ALGORITHMS.A256GCM,
     """Encrypts plaintext and returns a JWE cmpact serialization string.
 
     Args:
-        plaintext (bytes): A bytes object to encrypt
+        plaintext (str): A string to encrypt
         key (str or dict): The key(s) to use for encrypting the content. Can be
             individual JWK or JWK set.
         encryption (str, optional): The content encryption algorithm used to
@@ -37,7 +37,7 @@ def encrypt(plaintext, key, encryption=ALGORITHMS.A256GCM,
         kid (str, optional): Key ID for the provided key
 
     Returns:
-        bytes: The string representation of the header, encrypted key,
+        str: The base64-encoded string representation of the header, encrypted key,
             initialization vector, ciphertext, and authentication tag.
 
     Raises:
@@ -74,7 +74,7 @@ def decrypt(jwe_str, key):
             individual JWK or JWK set.
 
     Returns:
-        bytes: The plaintext bytes, assuming the authentication tag is valid.
+        str: The base64-encoded str, assuming the authentication tag is valid.
 
     Raises:
         JWEError: If there is an exception verifying the token.

--- a/jose/jws.py
+++ b/jose/jws.py
@@ -80,7 +80,7 @@ def verify(token, key, algorithms, verify=True):
     if verify:
         _verify_signature(signing_input, header, signature, key, algorithms)
 
-    return payload
+    return payload.decode('utf-8')
 
 
 def get_unverified_header(token):
@@ -142,11 +142,11 @@ def _encode_header(algorithm, additional_headers=None):
     if additional_headers:
         header.update(additional_headers)
 
-    json_header = json.dumps(
+    json_header = six.ensure_binary(json.dumps(
         header,
         separators=(',', ':'),
         sort_keys=True,
-    ).encode('utf-8')
+    ))
 
     return base64url_encode(json_header)
 
@@ -157,11 +157,11 @@ def _encode_payload(payload):
             payload = json.dumps(
                 payload,
                 separators=(',', ':'),
-            ).encode('utf-8')
+            )
         except ValueError:
             pass
 
-    return base64url_encode(payload)
+    return base64url_encode(six.ensure_binary(payload))
 
 
 def _sign_header_and_claims(encoded_header, encoded_claims, algorithm, key):

--- a/jose/jws.py
+++ b/jose/jws.py
@@ -37,7 +37,7 @@ def sign(payload, key, headers=None, algorithm=ALGORITHMS.HS256):
         JWSError: If there is an error signing the token.
 
     Examples:
-
+        >>> from jose import jws
         >>> jws.sign({'a': 'b'}, 'secret', algorithm='HS256')
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
 
@@ -70,8 +70,10 @@ def verify(token, key, algorithms, verify=True):
 
     Examples:
 
+        >>> from jose import jws
         >>> token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
         >>> jws.verify(token, 'secret', algorithms='HS256')
+        '{"a":"b"}'
 
     """
 
@@ -94,6 +96,14 @@ def get_unverified_header(token):
 
     Raises:
         JWSError: If there is an exception decoding the token.
+
+    Examples:
+
+        >>> from jose import jws
+        >>> token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
+        >>> jws.get_unverified_header(token)
+        {'alg': 'HS256', 'typ': 'JWT'}
+
     """
     header, claims, signing_input, signature = _load(token)
     return header
@@ -113,6 +123,14 @@ def get_unverified_headers(token):
 
     Raises:
         JWSError: If there is an exception decoding the token.
+
+    Examples:
+
+        >>> from jose import jws
+        >>> token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
+        >>> jws.get_unverified_headers(token)
+        {'alg': 'HS256', 'typ': 'JWT'}
+
     """
     return get_unverified_header(token)
 
@@ -128,6 +146,14 @@ def get_unverified_claims(token):
 
     Raises:
         JWSError: If there is an exception decoding the token.
+
+    Examples:
+
+        >>> from jose import jws
+        >>> token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
+        >>> jws.get_unverified_claims(token)
+        b'{"a":"b"}'
+
     """
     header, claims, signing_input, signature = _load(token)
     return claims

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -46,6 +46,7 @@ def encode(claims, key, algorithm=ALGORITHMS.HS256, headers=None, access_token=N
 
     Examples:
 
+        >>> from jose import jwt
         >>> jwt.encode({'a': 'b'}, 'secret', algorithm='HS256')
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
 
@@ -119,8 +120,10 @@ def decode(token, key, algorithms=None, options=None, audience=None,
 
     Examples:
 
+        >>> from jose import jwt
         >>> payload = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
         >>> jwt.decode(payload, 'secret', algorithms='HS256')
+        {'a': 'b'}
 
     """
 

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -159,7 +159,7 @@ def decode(token, key, algorithms=None, options=None, audience=None,
     algorithm = jws.get_unverified_header(token)['alg']
 
     try:
-        claims = json.loads(payload.decode('utf-8'))
+        claims = json.loads(payload)
     except ValueError as e:
         raise JWTError('Invalid payload string: %s' % e)
 

--- a/jose/utils.py
+++ b/jose/utils.py
@@ -75,29 +75,29 @@ def calculate_at_hash(access_token, hash_alg):
     return at_hash.decode('utf-8')
 
 
-def base64url_decode(input):
+def base64url_decode(data):
     """Helper method to base64url_decode a string.
 
     Args:
-        input (str): A base64url_encoded string to decode.
+        data (str): A base64url_encoded string to decode.
 
     """
-    rem = len(input) % 4
+    rem = len(data) % 4
 
     if rem > 0:
-        input += b'=' * (4 - rem)
+        data += b'=' * (4 - rem)
 
-    return base64.urlsafe_b64decode(input)
+    return base64.urlsafe_b64decode(data)
 
 
-def base64url_encode(input):
+def base64url_encode(data):
     """Helper method to base64url_encode a string.
 
     Args:
-        input (str): A base64url_encoded string to encode.
+        data (str): A base64url_encoded string to encode.
 
     """
-    return base64.urlsafe_b64encode(input).replace(b'=', b'')
+    return base64.urlsafe_b64encode(data).replace(b'=', b'')
 
 
 def timedelta_total_seconds(delta):

--- a/jose/utils.py
+++ b/jose/utils.py
@@ -94,7 +94,7 @@ def base64url_encode(data):
     """Helper method to base64url_encode a string.
 
     Args:
-        data (str): A base64url_encoded string to encode.
+        data (str): A string to base64url encode.
 
     """
     return base64.urlsafe_b64encode(data).replace(b'=', b'')

--- a/jose/utils.py
+++ b/jose/utils.py
@@ -44,11 +44,9 @@ def int_arr_to_long(arr):
 
 
 def base64_to_long(data):
-    if isinstance(data, six.text_type):
-        data = data.encode("ascii")
-
+    data = six.ensure_binary(data)
     # urlsafe_b64decode will happily convert b64encoded data
-    _d = base64.urlsafe_b64decode(bytes(data) + b'==')
+    _d = base64.urlsafe_b64decode(data + b'==')
     return int_arr_to_long(struct.unpack('%sB' % len(_d), _d))
 
 
@@ -82,6 +80,8 @@ def base64url_decode(data):
         data (str): A base64url_encoded string to decode.
 
     """
+    data = six.ensure_binary(data)
+
     rem = len(data) % 4
 
     if rem > 0:

--- a/tests/rfc/test_rfc7520.py
+++ b/tests/rfc/test_rfc7520.py
@@ -4,8 +4,7 @@
 
 from jose.jws import verify
 
-expected_payload = b"It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to."
-
+expected_payload = b"It\xe2\x80\x99s a dangerous business, Frodo, going out your door. You step onto the road, and if you don't keep your feet, there\xe2\x80\x99s no knowing where you might be swept off to.".decode('utf-8')
 
 # [Docs] [txt|pdf] [draft-ietf-jose-c...]
 

--- a/tests/test_jwe.py
+++ b/tests/test_jwe.py
@@ -302,7 +302,7 @@ class TestDecrypt(object):
             pytest.skip("enc {} not supported".format(headers["enc"]))
         key = PRIVATE_KEY_PEM
         actual = jwe.decrypt(jwe_package, key)
-        assert actual == b"Live long and prosper."
+        assert actual == "Live long and prosper."
 
     @pytest.mark.parametrize("jwe_package", JWE_128_BIT_OCT_PACKAGES)
     def test_decrypt_oct_128_key_wrap(self, jwe_package):
@@ -313,7 +313,7 @@ class TestDecrypt(object):
         if headers["enc"] not in ALGORITHMS.SUPPORTED:
             pytest.skip("enc {} not supported".format(headers["enc"]))
         actual = jwe.decrypt(jwe_package, key)
-        assert actual == b"Live long and prosper."
+        assert actual == "Live long and prosper."
 
     @pytest.mark.parametrize("jwe_package", JWE_192_BIT_OCT_PACKAGES)
     def test_decrypt_oct_192_key_wrap(self, jwe_package):
@@ -324,7 +324,7 @@ class TestDecrypt(object):
             pytest.skip("enc {} not supported".format(headers["enc"]))
         key = OCT_192_BIT_KEY
         actual = jwe.decrypt(jwe_package, key)
-        assert actual == b"Live long and prosper."
+        assert actual == "Live long and prosper."
 
     @pytest.mark.parametrize("jwe_package", JWE_256_BIT_OCT_PACKAGES)
     def test_decrypt_oct_256_key_wrap(self, jwe_package):
@@ -335,7 +335,7 @@ class TestDecrypt(object):
             pytest.skip("enc {} not supported".format(headers["enc"]))
         key = OCT_256_BIT_KEY
         actual = jwe.decrypt(jwe_package, key)
-        assert actual == b"Live long and prosper."
+        assert actual == "Live long and prosper."
 
     def test_invalid_jwe_is_parse_error(self):
         with pytest.raises(JWEParseError):
@@ -375,7 +375,7 @@ class TestEncrypt(object):
         for backend in backends:
             monkeypatch.setattr(backend, "get_random_bytes", lambda x: expected_iv if x == 16 else key)
 
-        expected = b"eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..AxY8DCtDaGlsbGljb3RoZQ.KDlTtXchhZTGufMYmOYGS4HffxPSUrfmqCHXaI9wOGY.BIiCkt8mWOVyJOqDMwNqaQ"
+        expected = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..AxY8DCtDaGlsbGljb3RoZQ.KDlTtXchhZTGufMYmOYGS4HffxPSUrfmqCHXaI9wOGY.BIiCkt8mWOVyJOqDMwNqaQ"
         actual = jwe.encrypt(plain_text, key, encryption, algorithm)
 
         assert actual == expected
@@ -385,7 +385,7 @@ class TestEncrypt(object):
     @pytest.mark.parametrize("enc", filter(lambda x: x in ALGORITHMS.SUPPORTED, ALGORITHMS.AES_ENC))
     @pytest.mark.parametrize("zip", ZIPS.SUPPORTED)
     def test_encrypt_decrypt_rsa_kw(self, alg, enc, zip):
-        expected = b"Live long and prosper."
+        expected = "Live long and prosper."
         jwe_value = jwe.encrypt(expected[:], PUBLIC_KEY_PEM, enc, alg, zip)
         actual = jwe.decrypt(jwe_value, PRIVATE_KEY_PEM)
         assert actual == expected
@@ -403,7 +403,7 @@ class TestEncrypt(object):
             key = OCT_256_BIT_KEY
         else:
             pytest.fail("I don't know how to handle enc {}".format(alg))
-        expected = b"Live long and prosper."
+        expected = "Live long and prosper."
         jwe_value = jwe.encrypt(expected[:], key, enc, alg, zip)
         actual = jwe.decrypt(jwe_value, key)
         assert actual == expected
@@ -424,7 +424,7 @@ class TestEncrypt(object):
             key = OCT_512_BIT_KEY
         else:
             pytest.fail("I don't know how to handle enc {}".format(enc))
-        expected = b"Live long and prosper."
+        expected = "Live long and prosper."
         jwe_value = jwe.encrypt(expected[:], key, enc, ALGORITHMS.DIR, zip)
         actual = jwe.decrypt(jwe_value, key)
         assert actual == expected
@@ -434,7 +434,7 @@ class TestEncrypt(object):
         enc = ALGORITHMS.A256CBC_HS512
         alg = ALGORITHMS.RSA_OAEP_256
         encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg)
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert header["enc"] == enc
         assert header["alg"] == alg
 
@@ -444,7 +444,7 @@ class TestEncrypt(object):
         alg = ALGORITHMS.RSA_OAEP_256
         encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg,
                                 cty="expected")
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert header["cty"] == "expected"
 
     @pytest.mark.skipif(AESKey is None, reason="No AES backend")
@@ -452,24 +452,24 @@ class TestEncrypt(object):
         enc = ALGORITHMS.A256CBC_HS512
         alg = ALGORITHMS.RSA_OAEP_256
         encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg)
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert "cty" not in header
 
     @pytest.mark.skipif(AESKey is None, reason="No AES backend")
     def test_zip_header_present_when_provided(self):
         enc = ALGORITHMS.A256CBC_HS512
         alg = ALGORITHMS.RSA_OAEP_256
-        encrypted = jwe.encrypt(b"Text", PUBLIC_KEY_PEM, enc, alg,
+        encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg,
                                 zip=ZIPS.DEF)
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert header["zip"] == ZIPS.DEF
 
     @pytest.mark.skipif(AESKey is None, reason="No AES backend")
     def test_zip_header_not_present_when_not_provided(self):
         enc = ALGORITHMS.A256CBC_HS512
         alg = ALGORITHMS.RSA_OAEP_256
-        encrypted = jwe.encrypt(b"Text", PUBLIC_KEY_PEM, enc, alg)
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg)
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert "zip" not in header
 
     @pytest.mark.skipif(AESKey is None, reason="No AES backend")
@@ -478,7 +478,7 @@ class TestEncrypt(object):
         alg = ALGORITHMS.RSA_OAEP_256
         encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg,
                                 zip=ZIPS.NONE)
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert "zip" not in header
 
     @pytest.mark.skipif(AESKey is None, reason="No AES backend")
@@ -487,7 +487,7 @@ class TestEncrypt(object):
         alg = ALGORITHMS.RSA_OAEP_256
         encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg,
                                 kid="expected")
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert header["kid"] == "expected"
 
     @pytest.mark.skipif(AESKey is None, reason="No AES backend")
@@ -495,5 +495,5 @@ class TestEncrypt(object):
         enc = ALGORITHMS.A256CBC_HS512
         alg = ALGORITHMS.RSA_OAEP_256
         encrypted = jwe.encrypt("Text", PUBLIC_KEY_PEM, enc, alg)
-        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(b".")[0])))
+        header = json.loads(six.ensure_str(base64url_decode(encrypted.split(".")[0])))
         assert "kid" not in header

--- a/tests/test_jws.py
+++ b/tests/test_jws.py
@@ -17,7 +17,7 @@ except ImportError:
 
 @pytest.fixture
 def payload():
-    payload = b"test payload"
+    payload = "test payload"
     return payload
 
 
@@ -84,7 +84,7 @@ class TestJWS(object):
     def test_round_trip_with_different_key_types(self, key):
         signed_data = jws.sign({'testkey': 'testvalue'}, key, algorithm=ALGORITHMS.HS256)
         verified_bytes = jws.verify(signed_data, key, algorithms=[ALGORITHMS.HS256])
-        verified_data = json.loads(verified_bytes.decode('utf-8'))
+        verified_data = json.loads(verified_bytes)
         assert 'testkey' in verified_data.keys()
         assert verified_data['testkey'] == 'testvalue'
 
@@ -290,7 +290,7 @@ class TestRSA(object):
     def test_jwk_set(self, jwk_set):
         # Would raise a JWSError if validation failed.
         payload = jws.verify(google_id_token, jwk_set, ALGORITHMS.RS256)
-        iss = json.loads(payload.decode('utf-8'))['iss']
+        iss = json.loads(payload)['iss']
         assert iss == "https://accounts.google.com"
 
     def test_jwk_set_failure(self, jwk_set):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -65,7 +65,7 @@ class TestJWT:
             token = u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
 
             def return_invalid_json(token, key, algorithms, verify=True):
-                return b'["a", "b"}'
+                return '["a", "b"}'
 
             jws.verify = return_invalid_json
 
@@ -80,7 +80,7 @@ class TestJWT:
             token = u'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8'
 
             def return_encoded_array(token, key, algorithms, verify=True):
-                return b'["a","b"]'
+                return '["a","b"]'
 
             jws.verify = return_encoded_array
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ b64_to_bstr = [
 ]
 
 b64b_to_bstr = [
-    (b64.encode('ascii'), bstr)
+    (b64.encode('utf-8'), bstr)
     for (b64, bstr) in b64_to_bstr
 ]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,29 @@
 
 from datetime import timedelta
 
+import pytest
+
 from jose import utils
+
+
+b64_to_bstr = [
+    ('', b''),
+    ('YQ', b'a'),
+    ('YXM', b'as'),
+    ('YXNk', b'asd'),
+    ('YXNkZg', b'asdf'),
+    ('YXNkZnE', b'asdfq'),
+    ('YXNkZnF3', b'asdfqw'),
+    ('YXNkZnF3ZQ', b'asdfqwe'),
+    ('YXNkZnF3ZXI', b'asdfqwer'),
+    ('YXNkZnF3ZXJ0', b'asdfqwert'),
+    ('YXNkZnF3ZXJ0eQ', b'asdfqwerty'),
+]
+
+b64b_to_bstr = [
+    (b64.encode('ascii'), bstr)
+    for (b64, bstr) in b64_to_bstr
+]
 
 
 class TestUtils:
@@ -11,6 +33,21 @@ class TestUtils:
 
         assert utils.timedelta_total_seconds(td) == 5
 
-    def test_long_to_base64(self):
-        assert utils.long_to_base64(0xDEADBEEF) == b'3q2-7w'
-        assert utils.long_to_base64(0xCAFED00D, size=10) == b'AAAAAAAAyv7QDQ'
+    @pytest.mark.parametrize("longdata, kwargs, b64", [
+        (0xDEADBEEF, {}, b'3q2-7w'),
+        (0xCAFED00D, {'size': 10}, b'AAAAAAAAyv7QDQ'),
+    ])
+    def test_long_to_base64(self, longdata, kwargs, b64):
+        assert utils.long_to_base64(longdata, **kwargs) == b64
+
+    @pytest.mark.parametrize("b64b, bstr", b64b_to_bstr)
+    def test_base64url_encode_bytes(self, b64b, bstr):
+        assert b64b == utils.base64url_encode(bstr)
+
+    @pytest.mark.parametrize("b64b, bstr", b64b_to_bstr)
+    def test_base64url_decode_bytes(self, b64b, bstr):
+        assert utils.base64url_decode(b64b) == bstr
+
+    @pytest.mark.parametrize("b64str, bstr", b64_to_bstr)
+    def test_base64url_decode_string(self, b64str, bstr):
+        assert utils.base64url_decode(b64str) == bstr

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 skip_missing_interpreters = True
 
 [testenv:basecommand]
+# Run without doctests by default - they only pass in a compatibility environment
 commands =
     pip --version
     py.test --cov-report term-missing --cov jose {posargs}
@@ -23,6 +24,10 @@ commands =
     py.test
 
 [testenv:compatibility]
+# Run with coverage and with doctests
+commands =
+    pip --version
+    py.test --doctest-modules --cov-report term-missing --cov jose {posargs}
 extras =
     cryptography
     pycrypto


### PR DESCRIPTION
### Note: This PR description is not yet finished, and I may rewrite some of these commits, so if you pull this branch, beware that you may need to rebase any changes you make to it! ###

Python 2 treated bytestrings and character strings as the same thing, a mistake that was thankfully fixed in Python 3. However, this did create a dilemma when updating this codebase to run on Python 3 - should module functions return bytestrings or character strings? Many, if not all, encryption packages sidestep this issue by foisting the distinction and conversion processes onto users, however, that makes implementing robust and correct applications more difficult.

Users of this package who have been running on Python 3 have come across many sharp edges of the `bytes`/`str` divide and reported them across multiple issues (#51, #153, #183, #184), and so with the update to Python 3, it has become imperative for this package to "take a stand" on the basic data structure it expects to handle. 

I searched through RFC 7520 for "byte", "bytes", and "binary" and found only one instance:

> All instances of binary octet strings are represented using base64url [RFC4648] encoding.

This indicates to me that the governing standard for this project does not want to deal with bytestrings directly, instead dealing with them indirectly via base64-urlencoding.

Python 2.7 makes base64-encoding bytestrings and strings easy, and both are base64-encoded to `str`:

```python
Python 2.7.16 (default, Jan 27 2020, 04:46:15)
[GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.37.14)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import base64
>>> base64.b64encode(b'Hello Binary World')
'SGVsbG8gQmluYXJ5IFdvcmxk'
>>> type(base64.b64encode(b'Hello Binary World'))
<type 'str'>
>>> 
>>> base64.b64encode('Hello String World')
'SGVsbG8gU3RyaW5nIFdvcmxk'
>>> type(base64.b64encode('Hello String World'))
<type 'str'>
```

To summarize the types that are expected and returned:

* `bytes` -> `str`
* `str` -> `str`

Python 3.6 makes things more complex - users have to manually encode strings to bytes before base64-encoding them, and :

```python
Python 3.6.4 (v3.6.4:d48ecebad5, Dec 18 2017, 21:07:28)
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import base64
>>> base64.b64encode(b'Hello Binary World')
b'SGVsbG8gQmluYXJ5IFdvcmxk'
>>> type(base64.b64encode(b'Hello Binary World'))
<class 'bytes'>
>>> 
>>> base64.b64encode('Hello String World')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
TypeError: a bytes-like object is required, not 'str'
>>> type(base64.b64encode('Hello String World'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
TypeError: a bytes-like object is required, not 'str'
```

Summarizing those type expectations:

* `bytes` -> `bytes`
* ~`str` -> (exception)~

So Python 2.7 will accept `bytes` and `str` and returns a `str`, but Python 3 only accepts `bytes` and returns `bytes`. This impacts everybody who is using Python 3, not just users of this library. Unfortunately, it's not the behavior we would like.