### PR TITLE
Unpin ecdsa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycryptodome
 six
 rsa
-ecdsa<0.15
+ecdsa
 pyasn1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycryptodome
 six
 rsa
-ecdsa
+ecdsa != 0.15
 pyasn1


### PR DESCRIPTION
There is a newer version of ecdsa `0.16.0`. We can unpin version, because all of tests passed.