### PR TITLE
Denylist ecdsa 0.15 in setup.py to allow for 0.16 to be installed.

### DIFF
--- a/jose/backends/ecdsa_backend.py
+++ b/jose/backends/ecdsa_backend.py
@@ -91,11 +91,22 @@ class ECDSAECKey(Key):
             return ecdsa.keys.VerifyingKey.from_public_point(point, self.curve)
 
     def sign(self, msg):
-        return self.prepared_key.sign(msg, hashfunc=self.hash_alg, sigencode=ecdsa.util.sigencode_string, allow_truncate=False)
+        return self.prepared_key.sign(
+            msg,
+            hashfunc=self.hash_alg,
+            sigencode=ecdsa.util.sigencode_string,
+            allow_truncate=False
+        )
 
     def verify(self, msg, sig):
         try:
-            return self.prepared_key.verify(sig, msg, hashfunc=self.hash_alg, sigdecode=ecdsa.util.sigdecode_string, allow_truncate=False)
+            return self.prepared_key.verify(
+                sig,
+                msg,
+                hashfunc=self.hash_alg,
+                sigdecode=ecdsa.util.sigdecode_string,
+                allow_truncate=False
+            )
         except Exception:
             return False
 

--- a/jose/backends/ecdsa_backend.py
+++ b/jose/backends/ecdsa_backend.py
@@ -91,11 +91,11 @@ class ECDSAECKey(Key):
             return ecdsa.keys.VerifyingKey.from_public_point(point, self.curve)
 
     def sign(self, msg):
-        return self.prepared_key.sign(msg, hashfunc=self.hash_alg, sigencode=ecdsa.util.sigencode_string)
+        return self.prepared_key.sign(msg, hashfunc=self.hash_alg, sigencode=ecdsa.util.sigencode_string, allow_truncate=False)
 
     def verify(self, msg, sig):
         try:
-            return self.prepared_key.verify(sig, msg, hashfunc=self.hash_alg, sigdecode=ecdsa.util.sigdecode_string)
+            return self.prepared_key.verify(sig, msg, hashfunc=self.hash_alg, sigdecode=ecdsa.util.sigdecode_string, allow_truncate=False)
         except Exception:
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
     'pycrypto': ['pycrypto >=2.6.0, <2.7.0'] + pyasn1,
     'pycryptodome': ['pycryptodome >=3.3.1, <4.0.0'] + pyasn1,
 }
-legacy_backend_requires = ['ecdsa <0.15', 'rsa'] + pyasn1
+legacy_backend_requires = ['ecdsa != 0.15', 'rsa'] + pyasn1
 install_requires = ['six <2.0']
 
 # TODO: work this into the extras selection instead.
@@ -78,7 +78,7 @@ setup(
     ],
     tests_require=[
         'six',
-        'ecdsa<0.15',
+        'ecdsa != 0.15',
         'pytest',
         'pytest-cov',
         'pytest-runner',


### PR DESCRIPTION
The previous pull request #192 only changed the pin in requirements.txt and not in setup.py, so the ecdsa<0.15 restriction would actually be used by pip.