### PR TITLE
chore: fix cryptography warning

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -20,8 +20,13 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, aead, mod
 from cryptography.hazmat.primitives.keywrap import aes_key_wrap, aes_key_unwrap, InvalidUnwrap
 from cryptography.hazmat.primitives.padding import PKCS7
 from cryptography.hazmat.primitives.serialization import load_pem_private_key, load_pem_public_key
-from cryptography.utils import int_from_bytes, int_to_bytes
 from cryptography.x509 import load_pem_x509_certificate
+
+if not hasattr(int, "from_bytes"):
+    from cryptography.utils import int_from_bytes, int_to_bytes
+else:
+    from cryptography.utils import int_to_bytes
+    int_from_bytes = int.from_bytes
 
 _binding = None
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def _cryptography_version():
     if platform.python_implementation() == 'PyPy' and platform.python_version() < '5.4':
         return 'cryptography < 2.5'
 
-    return 'cryptography'
+    return 'cryptography < 3.5'
 
 
 pyasn1 = ['pyasn1']


### PR DESCRIPTION
Fix a warning emitted by `cryptography` since a recent release.
```
/usr/local/lib/python3.7/site-packages/jose/backends/cryptography_backend.py:18: CryptographyDeprecationWarning: int_from_bytes is deprecated, use int.from_bytes instead
  from cryptography.utils import int_from_bytes, int_to_bytes
```

Edit:
The warning comes from cryptography 3.4 release. Since this release only python 3.6+ is supported.
This PR fixes the warning by using `int.from_bytes`, which is only available since python 3.2.
So obviously python 2.7 is not supported anymore cryptography.

So the solutions for python-jose are:
1. drop python 2 support completely. This is the right solution IMO, it's 2021 after all.
2. pin the cryptography dep in setup.py to `<3.4` if python 2 is detected and make the imports conditional. Defining the deps a bit more strictly would make sense anyways.