### PR TITLE
Rename flake8 step/env to lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,4 +50,4 @@ jobs:
       run: |
         pip install -U setuptools 
         pip install -U "tox>=3.23.0,<4"
-    - run: tox -e flake8
+    - run: tox -e lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     # Linting
     - python: 3.8
-      env: TOXENV=flake8
+      env: TOXENV=lint
     # CPython 3.6
     - python: 3.6
       env: TOXENV=py36-base

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.4.0
 envlist =
     py{36,37,38,39,py3}-{base,cryptography-only,pycryptodome-norsa,compatibility},
-    flake8
+    lint
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -55,7 +55,7 @@ extras =
     pycryptodome: pycryptodome
     compatibility: {[testenv:compatibility]extras}
 
-[testenv:flake8]
+[testenv:lint]
 basepython = python3.8
 skip_install= True
 deps =


### PR DESCRIPTION
going to add some more tools (isort & black) so making this step/env a more generic name.