### PR TITLE
Add more OS (windows, mac-os) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: main
+name: CI
 on:
   push:
     branches:
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: macos-latest
             python-version:  "pypy3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: [macos-latest, windows-latest]
+          - os: macos-latest
+            python-version:  "pypy3"
+          - os: windows-latest
             python-version:  "pypy3"
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
-          - os: macos-latest
+          - os: [macos-latest, windows-latest]
             python-version:  "pypy3"
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,14 @@ on:
       - master
 jobs:
   test:
-    runs-on: "ubuntu-latest"
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: "${{ matrix.os }}) Python: ${{ matrix.python-version }}"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,11 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
         os: [ubuntu-latest, macos-latest]
+        exclude:
+          - os: macos-latest
+            python-version:  "pypy3"
     runs-on: ${{ matrix.os }}
-    name: "${{ matrix.os }}) Python: ${{ matrix.python-version }}"
+    name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Underlying packages depend on native libraries so it is important to make sure things work across multiple operating systems. Github Actions makes it trivial.
