### PR TITLE
Add python_requires arg to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "pytest-runner",
         "setuptools>=39.2.0",
     ],
+    python_requires=">=3.6",
     tests_require=[
         "ecdsa != 0.15",
         "pytest",


### PR DESCRIPTION
This prevents pip from attempting to install new python-jose packages on
unsupported Python versions.

See https://packaging.python.org/tutorials/packaging-projects/#configuring-metadata