### PR TITLE
Added possibility to call jwk.construct() with a private RSA key

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -243,8 +243,8 @@ class CryptographyRSAKey(Key):
 
         self.cryptography_backend = cryptography_backend
 
-        # if it conforms to RSAPublicKey interface
-        if hasattr(key, "public_bytes") and hasattr(key, "public_numbers"):
+        # if it conforms to RSAPublicKey or RSAPrivateKey interface
+        if (hasattr(key, "public_bytes") and hasattr(key, "public_numbers")) or hasattr(key, "private_bytes"):
             self.prepared_key = key
             return
 


### PR DESCRIPTION
Pull request that fixes #282. It's working for me and it doesn't look like anything else should break because of this change, because everywhere the public interface is used, the code ensures it's working on the public part. It seems in line with similar code already present for `CryptographyECKey`. This change is for `CryptographyRSAKey` only.