### PR TITLE
docs: Fix a few typos

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,6 @@
 * Refactor Algorithm logic with set Exceptions to return
 * Add HTML documentation
 * Implement ECSDA signing
-* Refactor JWT claims verifcation
+* Refactor JWT claims verification
 * Add actual exceptions instead of using the base exception
 * Audit JWT claims tests and rectify against the spec

--- a/jose/jwe.py
+++ b/jose/jwe.py
@@ -12,7 +12,7 @@ from .utils import base64url_decode, base64url_encode, ensure_binary
 
 
 def encrypt(plaintext, key, encryption=ALGORITHMS.A256GCM, algorithm=ALGORITHMS.DIR, zip=None, cty=None, kid=None):
-    """Encrypts plaintext and returns a JWE cmpact serialization string.
+    """Encrypts plaintext and returns a JWE compact serialization string.
 
     Args:
         plaintext (bytes): A bytes object to encrypt
@@ -530,7 +530,7 @@ def _get_key_wrap_cek(enc, key):
 
 def _get_random_cek_bytes_for_enc(enc):
     """
-    Get the random cek bytes based on the encryptionn algorithm
+    Get the random cek bytes based on the encryption algorithm
 
     Args:
         enc (str): Encryption algorithm


### PR DESCRIPTION
There are small typos in:
- TODO.md
- jose/jwe.py

Fixes:
- Should read `verification` rather than `verifcation`.
- Should read `encryption` rather than `encryptionn`.
- Should read `compact` rather than `cmpact`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md