### PR TITLE
Use correct iv size (#281)

### DIFF
--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -468,7 +468,7 @@ class CryptographyAESKey(Key):
     def encrypt(self, plain_text, aad=None):
         plain_text = ensure_binary(plain_text)
         try:
-            iv = get_random_bytes(algorithms.AES.block_size // 8)
+            iv = get_random_bytes(16 if self._mode == modes.CBC else 12)
             mode = self._mode(iv)
             if mode.name == "GCM":
                 cipher = aead.AESGCM(self._key)


### PR DESCRIPTION
Use a 12 byte IV for GCM based algorithms and 16 byte IV for CBC based ones. This makes a JWE compatible with other libraries based on OpenSSL which can only use a 12 byte IV for GCM.