### PR TITLE
fixed get_unverified_claims() args description

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -98,7 +98,7 @@ def get_unverified_headers(token):
     compatibility.
 
     Args:
-        token (str): A signed JWS to decode the headers from.
+        token (str): A signed JWS to decode the claiams from.
 
     Returns:
         dict: The dict representation of the token headers.


### PR DESCRIPTION
I fixed a mistake in get_unverified_claims() docs about argument description, changed headers to claims.