### PR TITLE
[fix] DeprecationWarning for import Mapping , Iterable from collectio…

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -1,7 +1,9 @@
 import binascii
 import json
-from collections.abc import Iterable, Mapping
-
+try:
+    from collections.abc import Mapping, Iterable
+except ImportError:
+    from collections import Mapping, Iterable
 from jose import jwk
 from jose.backends.base import Key
 from jose.constants import ALGORITHMS

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -1,6 +1,9 @@
 import json
 from calendar import timegm
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from datetime import datetime, timedelta
 
 from jose import jws


### PR DESCRIPTION
Hello, we get warring in our application :``` DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working ```

and we fix it by replace  it with new import 
file : ``` jws.py ```
from
```python
from collections import Mapping, Iterable
```
to
```python
try:
    from collections.abc import Mapping, Iterable
except ImportError:
    from collections import Mapping, Iterable
```



file :``` jwt.py ```
from
```python
from collections import Mapping
```
to
```python
try:
    from collections.abc import Mapping
except ImportError:
    from collections import Mapping
```
