### PR TITLE
Don't fail CI on codecov upload errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
   linting:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Seeing a ton of HTTP 502 and other errors on codecov uploads. this should be breaking CI.
see also: https://github.com/codecov/codecov-action/issues/926
![Screenshot 2023-05-03 at 11 34 22 AM](https://user-images.githubusercontent.com/1268088/235965432-146c38ab-7ddd-425c-b1d3-b471394d689d.png)
