### PR TITLE
Updated pyasn version to match latest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 install_requires =
     ecdsa != 0.15
     rsa >=4.0, <5.0, !=4.4, !=4.1.1
-    pyasn1 >=0.4.1, <0.5.0
+    pyasn1 >=0.5.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Updated pyasn to match version 0.5.0. Seems to be passing all tests as well .
Closes: #312  
