### PR TITLE
Fix small mistake on HMAC jwk example

### DIFF
--- a/docs/jwk/index.rst
+++ b/docs/jwk/index.rst
@@ -26,7 +26,7 @@ Verifying token signatures
     >>> key = jwk.construct(hmac_key)
     >>>
     >>> message, encoded_sig = token.rsplit('.', 1)
-    >>> decoded_sig = base64url_decode(encoded_sig)
+    >>> decoded_sig = base64url_decode(encoded_sig.encode())
     >>> key.verify(message, decoded_sig)
 
 


### PR DESCRIPTION
```python
>>> decoded_sig = base64url_decode(encoded_sig)
Traceback (most recent call last):
(...)
  File "(...)/python3.11/site-packages/jose/utils.py", line 76, in base64url_decode
    input += b"=" * (4 - rem)
TypeError: can only concatenate str (not "bytes") to str
>>> decoded_sig = base64url_decode(encoded_sig.encode())
>>>
```