### PR TITLE
Updating `CryptographyAESKey::encrypt` to generate 96 bit IVs for GCM block cipher mode to adhere to JWA RFC

### DIFF
--- a/jose/backends/_asn1.py
+++ b/jose/backends/_asn1.py
@@ -2,6 +2,7 @@
 
 Required by rsa_backend but not cryptography_backend.
 """
+
 from pyasn1.codec.der import decoder, encoder
 from pyasn1.type import namedtype, univ
 

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -439,6 +439,8 @@ class CryptographyAESKey(Key):
         ALGORITHMS.A256KW: None,
     }
 
+    IV_BYTE_LENGTH_MODE_MAP = {"CBC": algorithms.AES.block_size // 8, "GCM": 96 // 8}
+
     def __init__(self, key, algorithm):
         if algorithm not in ALGORITHMS.AES:
             raise JWKError("%s is not a valid AES algorithm" % algorithm)
@@ -468,7 +470,8 @@ class CryptographyAESKey(Key):
     def encrypt(self, plain_text, aad=None):
         plain_text = ensure_binary(plain_text)
         try:
-            iv = get_random_bytes(algorithms.AES.block_size // 8)
+            iv_byte_length = self.IV_BYTE_LENGTH_MODE_MAP.get(self._mode.name, algorithms.AES.block_size)
+            iv = get_random_bytes(iv_byte_length)
             mode = self._mode(iv)
             if mode.name == "GCM":
                 cipher = aead.AESGCM(self._key)

--- a/tests/test_asn1.py
+++ b/tests/test_asn1.py
@@ -1,4 +1,5 @@
 """Tests for ``jose.backends._asn1``."""
+
 import base64
 
 import pytest

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,4 +1,5 @@
 """Test the default import handling."""
+
 try:
     from jose.backends.rsa_backend import RSAKey as PurePythonRSAKey
 except ImportError:


### PR DESCRIPTION
Updating `CryptographyAESKey::encrypt` to generate 96 bit IVs for GCM block cipher mode to adhere to the RFC for JWA in `jose/backends/cryptography_backend.py`

See https://www.rfc-editor.org/rfc/rfc7518.html#section-5.3 for the official RFC requirements for JWA

See https://github.com/panva/jose/issues/678 for related discussion on this issue

### Testing done

Ran the following commands, which successfully built the package and passed all unit tests that were not already failing:

```bash
# Setup python-jose project
git clone git@github.com:twwildey/python-jose.git

# Install dependencies for python-jose
cd python-jose
python -m venv .venv
source .venv/bin/activate
python3 -m pip install --upgrade build
python3 -m pip install -r requirements.txt
python3 -m pip install -r requirements-dev.txt

# Build project
python -m build

# Run tests for project
python -m pytest
```