### PR TITLE
Adding `get_pem_for_key` and `normalize_pem` methods to normalize PEM formatting of keys

### DIFF
--- a/tests/algorithms/test_EC_compat.py
+++ b/tests/algorithms/test_EC_compat.py
@@ -7,7 +7,7 @@ except ImportError:
     ECDSAECKey = CryptographyECKey = None
 from jose.constants import ALGORITHMS
 
-from .test_EC import private_key
+from .test_EC import get_pem_for_key, normalize_pem, private_key
 
 
 @pytest.mark.backend_compatibility
@@ -37,7 +37,7 @@ class TestBackendEcdsaCompatibility:
         key = BackendFrom(private_key, ALGORITHMS.ES256)
         key2 = BackendTo(private_key, ALGORITHMS.ES256)
 
-        assert key.public_key().to_pem().strip() == key2.public_key().to_pem().strip()
+        assert normalize_pem(get_pem_for_key(key.public_key())) == normalize_pem(get_pem_for_key(key2.public_key()))
 
     @pytest.mark.parametrize("BackendFrom", [ECDSAECKey, CryptographyECKey])
     @pytest.mark.parametrize("BackendTo", [ECDSAECKey, CryptographyECKey])
@@ -45,7 +45,7 @@ class TestBackendEcdsaCompatibility:
         key = BackendFrom(private_key, ALGORITHMS.ES256)
         key2 = BackendTo(private_key, ALGORITHMS.ES256)
 
-        assert key.to_pem().strip() == key2.to_pem().strip()
+        assert normalize_pem(get_pem_for_key(key)) == normalize_pem(get_pem_for_key(key2))
 
     @pytest.mark.parametrize("BackendFrom", [ECDSAECKey, CryptographyECKey])
     @pytest.mark.parametrize("BackendTo", [ECDSAECKey, CryptographyECKey])
@@ -53,19 +53,19 @@ class TestBackendEcdsaCompatibility:
         key = BackendFrom(private_key, ALGORITHMS.ES256)
         pubkey = key.public_key()
 
-        pub_pem_source = pubkey.to_pem().strip()
+        pub_pem_source = normalize_pem(get_pem_for_key(pubkey))
 
         pub_target = BackendTo(pub_pem_source, ALGORITHMS.ES256)
 
-        assert pub_pem_source == pub_target.to_pem().strip()
+        assert pub_pem_source == normalize_pem(get_pem_for_key(pub_target))
 
     @pytest.mark.parametrize("BackendFrom", [ECDSAECKey, CryptographyECKey])
     @pytest.mark.parametrize("BackendTo", [ECDSAECKey, CryptographyECKey])
     def test_private_key_load_cycle(self, BackendFrom, BackendTo):
         key = BackendFrom(private_key, ALGORITHMS.ES256)
 
-        pem_source = key.to_pem().strip()
+        pem_source = normalize_pem(get_pem_for_key(key))
 
         target = BackendTo(pem_source, ALGORITHMS.ES256)
 
-        assert pem_source == target.to_pem().strip()
+        assert pem_source == normalize_pem(get_pem_for_key(target))


### PR DESCRIPTION
Adding `get_pem_for_key` and `normalize_pem` methods to normalize PEM formatting of keys in `tests/algorithms/test_EC.py` and updating `tests/algorithms/test_EC_compat.py` to use these methods

Test failures were occurring due to differences of line lengths generated by the `cryptography` vs `ecdsa` PIP libraries for PEM formatting of cryptographic keys.  This method removes newlines from the bodies of PEM-formated keys so that test comparisons will not fail on differentiated line lengths between PEM formattings.

### Testing done

Ran the following:

```bash
python -m tox
```

Which succeeded:

```
pypy3-base: skipped because could not find python interpreter with spec(s): pypy3
pypy3-base: SKIP ⚠ in 0.03 seconds
pypy3-cryptography-only: skipped because could not find python interpreter with spec(s): pypy3
pypy3-cryptography-only: SKIP ⚠ in 0.01 seconds
pypy3-pycryptodome-norsa: skipped because could not find python interpreter with spec(s): pypy3
pypy3-pycryptodome-norsa: SKIP ⚠ in 0.02 seconds
pypy3-compatibility: skipped because could not find python interpreter with spec(s): pypy3
pypy3-compatibility: SKIP ⚠ in 0.02 seconds
lint: commands[0]> flake8 jose setup.py
lint: commands[1]> isort jose tests setup.py --check-only
lint: commands[2]> black . --check
All done! ✨ 🍰 ✨
38 files would be left unchanged.
  py37-base: SKIP (0.04 seconds)
  py37-cryptography-only: SKIP (0.01 seconds)
  py37-pycryptodome-norsa: SKIP (0.01 seconds)
  py37-compatibility: SKIP (0.01 seconds)
  py38-base: OK (11.13=setup[7.59]+cmd[0.39,3.16] seconds)
  py38-cryptography-only: OK (13.92=setup[5.05]+cmd[1.02,0.42,7.42] seconds)
  py38-pycryptodome-norsa: OK (7.88=setup[4.82]+cmd[1.03,0.44,1.59] seconds)
  py38-compatibility: OK (26.50=setup[4.88]+cmd[0.38,21.24] seconds)
  py39-base: OK (8.07=setup[4.89]+cmd[0.36,2.82] seconds)
  py39-cryptography-only: OK (13.51=setup[4.92]+cmd[0.99,0.40,7.20] seconds)
  py39-pycryptodome-norsa: OK (7.56=setup[4.71]+cmd[0.98,0.40,1.47] seconds)
  py39-compatibility: OK (26.49=setup[4.89]+cmd[0.44,21.16] seconds)
  py310-base: OK (7.71=setup[4.63]+cmd[0.35,2.73] seconds)
  py310-cryptography-only: OK (14.19=setup[4.53]+cmd[0.98,0.39,8.29] seconds)
  py310-pycryptodome-norsa: OK (7.63=setup[4.79]+cmd[1.01,0.42,1.42] seconds)
  py310-compatibility: OK (25.88=setup[4.60]+cmd[0.34,20.93] seconds)
  py311-base: OK (7.77=setup[4.71]+cmd[0.34,2.72] seconds)
  py311-cryptography-only: OK (13.23=setup[4.52]+cmd[1.00,0.38,7.33] seconds)
  py311-pycryptodome-norsa: OK (7.33=setup[4.55]+cmd[0.99,0.38,1.40] seconds)
  py311-compatibility: OK (26.22=setup[4.60]+cmd[0.34,21.28] seconds)
  pypy3-base: SKIP (0.03 seconds)
  pypy3-cryptography-only: SKIP (0.01 seconds)
  pypy3-pycryptodome-norsa: SKIP (0.01 seconds)
  pypy3-compatibility: SKIP (0.02 seconds)
  lint: OK (1.70=setup[0.02]+cmd[0.92,0.38,0.38] seconds)
  congratulations :) (227.00 seconds)
```