### PR TITLE
Disabling test build for Python 3.7 on OS X since arm64 is no longer supported on GitHub for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version:  "pypy3.9"
+          - os: macos-latest
+            python-version:  "3.7"
           - os: windows-latest
             python-version:  "pypy3.9"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Disabling test build for Python 3.7 on OS X since arm64 is no longer supported on GitHub for Python 3.7