### PR TITLE
Replace usage of deprecated datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -5,7 +5,7 @@ try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 from jose import jws
 
@@ -281,7 +281,7 @@ def _validate_nbf(claims, leeway=0):
     except ValueError:
         raise JWTClaimsError("Not Before claim (nbf) must be an integer.")
 
-    now = timegm(datetime.utcnow().utctimetuple())
+    now = timegm(datetime.now(UTC)().utctimetuple())
 
     if nbf > (now + leeway):
         raise JWTClaimsError("The token is not yet valid (nbf)")
@@ -311,7 +311,7 @@ def _validate_exp(claims, leeway=0):
     except ValueError:
         raise JWTClaimsError("Expiration Time claim (exp) must be an integer.")
 
-    now = timegm(datetime.utcnow().utctimetuple())
+    now = timegm(datetime.now(UTC)().utctimetuple())
 
     if exp < (now - leeway):
         raise ExpiredSignatureError("Signature has expired.")

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -5,7 +5,8 @@ try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
-from datetime import datetime, timedelta, UTC
+
+from datetime import UTC, datetime, timedelta
 
 from jose import jws
 

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -282,7 +282,7 @@ def _validate_nbf(claims, leeway=0):
     except ValueError:
         raise JWTClaimsError("Not Before claim (nbf) must be an integer.")
 
-    now = timegm(datetime.now(UTC)().utctimetuple())
+    now = timegm(datetime.now(UTC).utctimetuple())
 
     if nbf > (now + leeway):
         raise JWTClaimsError("The token is not yet valid (nbf)")
@@ -312,7 +312,7 @@ def _validate_exp(claims, leeway=0):
     except ValueError:
         raise JWTClaimsError("Expiration Time claim (exp) must be an integer.")
 
-    now = timegm(datetime.now(UTC)().utctimetuple())
+    now = timegm(datetime.now(UTC).utctimetuple())
 
     if exp < (now - leeway):
         raise ExpiredSignatureError("Signature has expired.")

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -8,9 +8,11 @@ except ImportError:
 
 try:
     from datetime import UTC, datetime, timedelta
+
     utc_now = datetime.now(UTC)  # Preferred in Python 3.13+
 except ImportError:
     from datetime import datetime, timedelta, timezone
+
     utc_now = datetime.now(timezone.utc)  # Preferred in Python 3.12 and below
     UTC = timezone.utc
 

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -6,7 +6,13 @@ try:
 except ImportError:
     from collections import Mapping
 
-from datetime import UTC, datetime, timedelta
+try:
+    from datetime import UTC, datetime, timedelta
+    utc_now = datetime.now(UTC)  # Preferred in Python 3.13+
+except ImportError:
+    from datetime import datetime, timedelta, timezone
+    utc_now = datetime.now(timezone.utc)  # Preferred in Python 3.12 and below
+    UTC = timezone.utc
 
 from jose import jws
 
@@ -386,7 +392,7 @@ def _validate_sub(claims, subject=None):
     "sub" value is a case-sensitive string containing a StringOrURI
     value.  Use of this claim is OPTIONAL.
 
-    Args:
+    Arg
         claims (dict): The claims dictionary to validate.
         subject (str): The subject of the token.
     """

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -3,9 +3,11 @@ import json
 
 try:
     from datetime import UTC, datetime, timedelta
+
     utc_now = datetime.now(UTC)  # Preferred in Python 3.13+
 except ImportError:
     from datetime import datetime, timedelta, timezone
+
     utc_now = datetime.now(timezone.utc)  # Preferred in Python 3.12 and below
     UTC = timezone.utc
 
@@ -92,9 +94,7 @@ class TestJWT:
 
             jws.verify = return_encoded_array
 
-            with pytest.raises(
-                JWTError, match="Invalid payload string: must be a json object"
-            ):
+            with pytest.raises(JWTError, match="Invalid payload string: must be a json object"):
                 jwt.decode(token, "secret", ["HS256"])
         finally:
             jws.verify = old_jws_verify
@@ -154,23 +154,12 @@ class TestJWT:
 
         # manually decode header to compare it to known good
         decoded_headers1 = base64url_decode(encoded_headers1.encode("utf-8"))
-        assert (
-            decoded_headers1
-            == b"""{"alg":"HS256","another_key":"another_value","kid":"my-key-id","typ":"JWT"}"""
-        )
+        assert decoded_headers1 == b"""{"alg":"HS256","another_key":"another_value","kid":"my-key-id","typ":"JWT"}"""
 
     def test_encode(self, claims, key):
         expected = (
-            (
-                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
-                ".eyJhIjoiYiJ9"
-                ".xNtk2S0CNbCBZX_f67pFgGRugaP1xi2ICfet3nwOSxw"
-            ),
-            (
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-                ".eyJhIjoiYiJ9"
-                ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"
-            ),
+            ("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" ".eyJhIjoiYiJ9" ".xNtk2S0CNbCBZX_f67pFgGRugaP1xi2ICfet3nwOSxw"),
+            ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ".eyJhIjoiYiJ9" ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"),
         )
 
         encoded = jwt.encode(claims, key)
@@ -178,11 +167,7 @@ class TestJWT:
         assert encoded in expected
 
     def test_decode(self, claims, key):
-        token = (
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-            ".eyJhIjoiYiJ9"
-            ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"
-        )
+        token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ".eyJhIjoiYiJ9" ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"
 
         decoded = jwt.decode(token, key)
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,6 +1,14 @@
 import base64
 import json
-from datetime import UTC, datetime, timedelta
+
+try:
+    from datetime import UTC, datetime, timedelta
+    utc_now = datetime.now(UTC)  # Preferred in Python 3.13+
+except ImportError:
+    from datetime import datetime, timedelta, timezone
+    utc_now = datetime.now(timezone.utc)  # Preferred in Python 3.12 and below
+    UTC = timezone.utc
+
 
 import pytest
 
@@ -84,7 +92,9 @@ class TestJWT:
 
             jws.verify = return_encoded_array
 
-            with pytest.raises(JWTError, match="Invalid payload string: must be a json object"):
+            with pytest.raises(
+                JWTError, match="Invalid payload string: must be a json object"
+            ):
                 jwt.decode(token, "secret", ["HS256"])
         finally:
             jws.verify = old_jws_verify
@@ -144,12 +154,23 @@ class TestJWT:
 
         # manually decode header to compare it to known good
         decoded_headers1 = base64url_decode(encoded_headers1.encode("utf-8"))
-        assert decoded_headers1 == b"""{"alg":"HS256","another_key":"another_value","kid":"my-key-id","typ":"JWT"}"""
+        assert (
+            decoded_headers1
+            == b"""{"alg":"HS256","another_key":"another_value","kid":"my-key-id","typ":"JWT"}"""
+        )
 
     def test_encode(self, claims, key):
         expected = (
-            ("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" ".eyJhIjoiYiJ9" ".xNtk2S0CNbCBZX_f67pFgGRugaP1xi2ICfet3nwOSxw"),
-            ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ".eyJhIjoiYiJ9" ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"),
+            (
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+                ".eyJhIjoiYiJ9"
+                ".xNtk2S0CNbCBZX_f67pFgGRugaP1xi2ICfet3nwOSxw"
+            ),
+            (
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                ".eyJhIjoiYiJ9"
+                ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"
+            ),
         )
 
         encoded = jwt.encode(claims, key)
@@ -157,7 +178,11 @@ class TestJWT:
         assert encoded in expected
 
     def test_decode(self, claims, key):
-        token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ".eyJhIjoiYiJ9" ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"
+        token = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            ".eyJhIjoiYiJ9"
+            ".jiMyrsmD8AoHWeQgmxZ5yq8z0lXS67_QGs52AzC8Ru8"
+        )
 
         decoded = jwt.decode(token, key)
 
@@ -504,8 +529,8 @@ class TestJWT:
         [
             ("aud", "aud"),
             ("ait", "ait"),
-            ("exp", datetime.now(UTC) + timedelta(seconds=3600)),
-            ("nbf", datetime.now(UTC) - timedelta(seconds=5)),
+            ("exp", utc_now + timedelta(seconds=3600)),
+            ("nbf", utc_now - timedelta(seconds=5)),
             ("iss", "iss"),
             ("sub", "sub"),
             ("jti", "jti"),

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 
 import pytest
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import pytest
 
@@ -180,7 +180,7 @@ class TestJWT:
         pass
 
     def test_leeway_is_timedelta(self, claims, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = datetime.now(UTC) + timedelta(seconds=5)
         leeway = timedelta(seconds=10)
 
         claims = {
@@ -209,7 +209,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_nbf_datetime(self, key):
-        nbf = datetime.utcnow() - timedelta(seconds=5)
+        nbf = datetime.now(UTC) - timedelta(seconds=5)
 
         claims = {"nbf": nbf}
 
@@ -217,7 +217,7 @@ class TestJWT:
         jwt.decode(token, key)
 
     def test_nbf_with_leeway(self, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = datetime.now(UTC) + timedelta(seconds=5)
 
         claims = {
             "nbf": nbf,
@@ -229,7 +229,7 @@ class TestJWT:
         jwt.decode(token, key, options=options)
 
     def test_nbf_in_future(self, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = datetime.now(UTC) + timedelta(seconds=5)
 
         claims = {"nbf": nbf}
 
@@ -239,7 +239,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_nbf_skip(self, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = datetime.now(UTC) + timedelta(seconds=5)
 
         claims = {"nbf": nbf}
 
@@ -261,7 +261,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_exp_datetime(self, key):
-        exp = datetime.utcnow() + timedelta(seconds=5)
+        exp = datetime.now(UTC) + timedelta(seconds=5)
 
         claims = {"exp": exp}
 
@@ -269,7 +269,7 @@ class TestJWT:
         jwt.decode(token, key)
 
     def test_exp_with_leeway(self, key):
-        exp = datetime.utcnow() - timedelta(seconds=5)
+        exp = datetime.now(UTC) - timedelta(seconds=5)
 
         claims = {
             "exp": exp,
@@ -281,7 +281,7 @@ class TestJWT:
         jwt.decode(token, key, options=options)
 
     def test_exp_in_past(self, key):
-        exp = datetime.utcnow() - timedelta(seconds=5)
+        exp = datetime.now(UTC) - timedelta(seconds=5)
 
         claims = {"exp": exp}
 
@@ -291,7 +291,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_exp_skip(self, key):
-        exp = datetime.utcnow() - timedelta(seconds=5)
+        exp = datetime.now(UTC) - timedelta(seconds=5)
 
         claims = {"exp": exp}
 
@@ -504,8 +504,8 @@ class TestJWT:
         [
             ("aud", "aud"),
             ("ait", "ait"),
-            ("exp", datetime.utcnow() + timedelta(seconds=3600)),
-            ("nbf", datetime.utcnow() - timedelta(seconds=5)),
+            ("exp", datetime.now(UTC) + timedelta(seconds=3600)),
+            ("nbf", datetime.now(UTC) - timedelta(seconds=5)),
             ("iss", "iss"),
             ("sub", "sub"),
             ("jti", "jti"),


### PR DESCRIPTION
Python 3.12 deprecates `datetime.utcnow()` in favor of using timezone-aware objects like `datetime.now(UTC)`. This commit updates the codebase accordingly to align with the latest recommendations.


https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
