### PR TITLE
fix: replaces deprecated utcnow with utility function

### DIFF
--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -11,7 +11,7 @@ from jose import jws
 
 from .constants import ALGORITHMS
 from .exceptions import ExpiredSignatureError, JWSError, JWTClaimsError, JWTError
-from .utils import calculate_at_hash, timedelta_total_seconds
+from .utils import calculate_at_hash, get_utc_now, timedelta_total_seconds
 
 
 def encode(claims, key, algorithm=ALGORITHMS.HS256, headers=None, access_token=None):
@@ -281,7 +281,7 @@ def _validate_nbf(claims, leeway=0):
     except ValueError:
         raise JWTClaimsError("Not Before claim (nbf) must be an integer.")
 
-    now = timegm(datetime.utcnow().utctimetuple())
+    now = timegm(get_utc_now().utctimetuple())
 
     if nbf > (now + leeway):
         raise JWTClaimsError("The token is not yet valid (nbf)")
@@ -311,7 +311,7 @@ def _validate_exp(claims, leeway=0):
     except ValueError:
         raise JWTClaimsError("Expiration Time claim (exp) must be an integer.")
 
-    now = timegm(datetime.utcnow().utctimetuple())
+    now = timegm(get_utc_now().utctimetuple())
 
     if exp < (now - leeway):
         raise ExpiredSignatureError("Signature has expired.")

--- a/jose/utils.py
+++ b/jose/utils.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import datetime, timezone
 import struct
 
 # Piggyback of the backends implementation of the function that converts a long
@@ -105,3 +106,8 @@ def ensure_binary(s):
     if isinstance(s, str):
         return s.encode("utf-8", "strict")
     raise TypeError(f"not expecting type '{type(s)}'")
+
+
+def get_utc_now():
+    """Returns a timezone-aware datetime, used in favor of deprecated datetime.utcnow"""
+    return datetime.now(timezone.utc)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,11 +1,12 @@
 import base64
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 
 from jose import jws, jwt
 from jose.exceptions import JWTError
+from jose.utils import get_utc_now
 
 
 @pytest.fixture
@@ -180,7 +181,7 @@ class TestJWT:
         pass
 
     def test_leeway_is_timedelta(self, claims, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = get_utc_now() + timedelta(seconds=5)
         leeway = timedelta(seconds=10)
 
         claims = {
@@ -209,7 +210,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_nbf_datetime(self, key):
-        nbf = datetime.utcnow() - timedelta(seconds=5)
+        nbf = get_utc_now() - timedelta(seconds=5)
 
         claims = {"nbf": nbf}
 
@@ -217,7 +218,7 @@ class TestJWT:
         jwt.decode(token, key)
 
     def test_nbf_with_leeway(self, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = get_utc_now() + timedelta(seconds=5)
 
         claims = {
             "nbf": nbf,
@@ -229,7 +230,7 @@ class TestJWT:
         jwt.decode(token, key, options=options)
 
     def test_nbf_in_future(self, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = get_utc_now() + timedelta(seconds=5)
 
         claims = {"nbf": nbf}
 
@@ -239,7 +240,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_nbf_skip(self, key):
-        nbf = datetime.utcnow() + timedelta(seconds=5)
+        nbf = get_utc_now() + timedelta(seconds=5)
 
         claims = {"nbf": nbf}
 
@@ -261,7 +262,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_exp_datetime(self, key):
-        exp = datetime.utcnow() + timedelta(seconds=5)
+        exp = get_utc_now() + timedelta(seconds=5)
 
         claims = {"exp": exp}
 
@@ -269,7 +270,7 @@ class TestJWT:
         jwt.decode(token, key)
 
     def test_exp_with_leeway(self, key):
-        exp = datetime.utcnow() - timedelta(seconds=5)
+        exp = get_utc_now() - timedelta(seconds=5)
 
         claims = {
             "exp": exp,
@@ -281,7 +282,7 @@ class TestJWT:
         jwt.decode(token, key, options=options)
 
     def test_exp_in_past(self, key):
-        exp = datetime.utcnow() - timedelta(seconds=5)
+        exp = get_utc_now() - timedelta(seconds=5)
 
         claims = {"exp": exp}
 
@@ -291,7 +292,7 @@ class TestJWT:
             jwt.decode(token, key)
 
     def test_exp_skip(self, key):
-        exp = datetime.utcnow() - timedelta(seconds=5)
+        exp = get_utc_now() - timedelta(seconds=5)
 
         claims = {"exp": exp}
 
@@ -504,8 +505,8 @@ class TestJWT:
         [
             ("aud", "aud"),
             ("ait", "ait"),
-            ("exp", datetime.utcnow() + timedelta(seconds=3600)),
-            ("nbf", datetime.utcnow() - timedelta(seconds=5)),
+            ("exp", get_utc_now() + timedelta(seconds=3600)),
+            ("nbf", get_utc_now() - timedelta(seconds=5)),
             ("iss", "iss"),
             ("sub", "sub"),
             ("jti", "jti"),


### PR DESCRIPTION
Fixes #334

Uses datetime.now(timezone.utc) as recommended in the [python docs deprecation note](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow:~:text=Warning%20Because%20naive%20datetime%20objects%20are%20treated%20by%20many%20datetime%20methods%20as%20local%20times%2C%20it%20is%20preferred%20to%20use%20aware%20datetimes%20to%20represent%20times%20in%20UTC.%20As%20such%2C%20the%20recommended%20way%20to%20create%20an%20object%20representing%20the%20current%20time%20in%20UTC%20is%20by%20calling%20datetime.now(timezone.utc).)