### PR TITLE
Do not use `utc_now` on module level

### DIFF
--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -1,5 +1,6 @@
 import json
 from calendar import timegm
+from datetime import datetime, timedelta
 
 try:
     from collections.abc import Mapping
@@ -7,14 +8,10 @@ except ImportError:
     from collections import Mapping
 
 try:
-    from datetime import UTC, datetime, timedelta
-
-    utc_now = datetime.now(UTC)  # Preferred in Python 3.13+
+    from datetime import UTC  # Preferred in Python 3.13+
 except ImportError:
     from datetime import datetime, timedelta, timezone
-
-    utc_now = datetime.now(timezone.utc)  # Preferred in Python 3.12 and below
-    UTC = timezone.utc
+    UTC = timezone.utc  # Preferred in Python 3.12 and below
 
 from jose import jws
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -1,14 +1,11 @@
 import base64
 import json
+from datetime import datetime, timedelta
 
 try:
-    from datetime import UTC, datetime, timedelta
-
-    utc_now = datetime.now(UTC)  # Preferred in Python 3.13+
+    from datetime import UTC  # Preferred in Python 3.13+
 except ImportError:
-    from datetime import datetime, timedelta, timezone
-
-    utc_now = datetime.now(timezone.utc)  # Preferred in Python 3.12 and below
+    from datetime import timezone  # Preferred in Python 3.12 and below
     UTC = timezone.utc
 
 
@@ -514,14 +511,16 @@ class TestJWT:
         [
             ("aud", "aud"),
             ("ait", "ait"),
-            ("exp", utc_now + timedelta(seconds=3600)),
-            ("nbf", utc_now - timedelta(seconds=5)),
+            ("exp", lambda: datetime.now(UTC) + timedelta(seconds=3600)),
+            ("nbf", lambda: datetime.now(UTC) - timedelta(seconds=5)),
             ("iss", "iss"),
             ("sub", "sub"),
             ("jti", "jti"),
         ],
     )
     def test_require(self, claims, key, claim, value):
+        if callable(value):
+            value = value()
         options = {"require_" + claim: True, "verify_" + claim: False}
 
         token = jwt.encode(claims, key)


### PR DESCRIPTION
Looks like that this value is never used anywhere, and it should not be, because it is created once on a module import time.

I found this while working on https://github.com/python/typeshed/pull/13514