### PR TITLE
Remove get_random_bytes from cryptography backend

### DIFF
--- a/jose/backends/__init__.py
+++ b/jose/backends/__init__.py
@@ -1,10 +1,4 @@
-try:
-    from jose.backends.cryptography_backend import get_random_bytes  # noqa: F401
-except ImportError:
-    try:
-        from jose.backends.pycrypto_backend import get_random_bytes  # noqa: F401
-    except ImportError:
-        from jose.backends.native import get_random_bytes  # noqa: F401
+from jose.backends.native import get_random_bytes  # noqa: F401
 
 try:
     from jose.backends.cryptography_backend import CryptographyRSAKey as RSAKey  # noqa: F401

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -24,8 +24,8 @@ from ..utils import (
     is_ssh_key,
     long_to_base64,
 )
-from .base import Key
 from . import get_random_bytes
+from .base import Key
 
 _binding = None
 

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -26,31 +26,9 @@ from ..utils import (
     long_to_base64,
 )
 from .base import Key
+from . import get_random_bytes
 
 _binding = None
-
-
-def get_random_bytes(num_bytes):
-    """
-    Get random bytes
-
-    Currently, Cryptography returns OS random bytes. If you want OpenSSL
-    generated random bytes, you'll have to switch the RAND engine after
-    initializing the OpenSSL backend
-    Args:
-        num_bytes (int): Number of random bytes to generate and return
-    Returns:
-        bytes: Random bytes
-    """
-    global _binding
-
-    if _binding is None:
-        _binding = Binding()
-
-    buf = _binding.ffi.new("char[]", num_bytes)
-    _binding.lib.RAND_bytes(buf, num_bytes)
-    rand_bytes = _binding.ffi.buffer(buf, num_bytes)[:]
-    return rand_bytes
 
 
 class CryptographyECKey(Key):

--- a/jose/backends/cryptography_backend.py
+++ b/jose/backends/cryptography_backend.py
@@ -3,7 +3,6 @@ import warnings
 
 from cryptography.exceptions import InvalidSignature, InvalidTag
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.bindings.openssl.binding import Binding
 from cryptography.hazmat.primitives import hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature


### PR DESCRIPTION
The RAND_bytes binding has been removed in cryptography 45.0. The
recommendation[1] is now to rely on `os.urandom`, which is already
implemented in the native backend.
The pycrpto implementation was removed earlier, so this removes the
leftover attempt to import it.

Closes: #380

[1] https://cryptography.io/en/latest/random-numbers/